### PR TITLE
fix: eRSD Warnings

### DIFF
--- a/data/SampleData/eCR/eCR_RR_combined_3_1.xml
+++ b/data/SampleData/eCR/eCR_RR_combined_3_1.xml
@@ -1,0 +1,3603 @@
+<!-- Sample 3.1 eCR and RR combined, run through the eCR Anonymization script -->
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <realmCode code="US" />
+    <typeId extension="POCD_HD000040" root="2.16.840.1.113883.1.3" />
+    <templateId root="1.2.840.114350.1.72.1.51693" />
+    <templateId root="2.16.840.1.113883.10.20.22.1.1" />
+    <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01" />
+    <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2023-05-01" />
+    <templateId root="2.16.840.1.113883.10.20.15.2" extension="2022-05-01" />
+    <id assigningAuthorityName="EPC" root="1.2.840.114350.1.13.4304.2.7.8.688883.1374" />
+    <code code="55751-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+        displayName="Initial Public Health Case Report" />
+    <title>Initial Public Health Case Report</title>
+    <effectiveTime value="19850728232826-0600" />
+    <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" displayName="Normal" />
+    <languageCode code="en-US" />
+    <setId assigningAuthorityName="EPC" extension="359d9b6c-da66-11ef-8f89-005056be2511"
+        root="1.2.840.114350.1.13.4304.2.7.1.1" />
+    <versionNumber value="1" />
+    <recordTarget>
+        <patientRole>
+            <id assigningAuthorityName="Social Security Administration" root="2.16.840.1.113883.4.1"
+                extension="XX5664558" />
+            <addr use="HP">
+                <streetAddressLine>9897 Kamino Ocean Street</streetAddressLine>
+                <county>Lah'mu</county>
+                <city>Galactic City</city>
+                <state>KZ</state>
+                <postalCode>79572</postalCode>
+                <country>AI</country>
+                <useablePeriod xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:type="IVL_TS">
+                    <low value="19811015" />
+                    <high nullFlavor="NA" />
+                </useablePeriod>
+            </addr>
+            <addr use="TMP">
+                <streetAddressLine>6903 KAMINO OCEAN Ave</streetAddressLine>
+                <county>Lah'mu</county>
+                <city>Galactic City</city>
+                <state>KZ</state>
+                <postalCode>79572</postalCode>
+                <country>AI</country>
+                <useablePeriod xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:type="IVL_TS">
+                    <low value="18601014" />
+                    <high value="19811014" />
+                </useablePeriod>
+            </addr>
+            <telecom use="HP" value="tel:+6-901-374-4286" />
+            <telecom value="mailto:cf@example.com" />
+            <patient>
+                <name use="L">
+                    <given>Fo</given>
+                    <family>Erso</family>
+                    <validTime>
+                        <low nullFlavor="NA" />
+                        <high nullFlavor="NA" />
+                    </validTime>
+                </name>
+                <administrativeGenderCode code="M" codeSystem="2.16.840.1.113883.5.1"
+                    codeSystemName="AdministrativeGenderCode" displayName="Male" />
+                <birthTime value="18601014" />
+                <sdtc:deceasedInd xmlns:sdtc="urn:hl7-org:sdtc" value="false" />
+                <maritalStatusCode code="S" codeSystem="2.16.840.1.113883.5.2"
+                    codeSystemName="MaritalStatusCode" displayName="Single" />
+                <raceCode code="2054-5" codeSystem="2.16.840.1.113883.6.238"
+                    codeSystemName="CDC Race and Ethnicity" displayName="Black or African American" />
+                <ethnicGroupCode code="2186-5" codeSystem="2.16.840.1.113883.6.238"
+                    codeSystemName="CDC Race and Ethnicity" displayName="Not Hispanic or Latino" />
+                <languageCommunication>
+                    <languageCode code="eng" />
+                    <preferenceInd value="true" />
+                </languageCommunication>
+            </patient>
+            <providerOrganization>
+                <id root="http://hl7.org/fhir/sid/us-npi" extension="XX22521268" />
+                <name>Academy of Agamar Research Institute</name>
+                <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                <addr use="WP">
+                    <streetAddressLine>554 KAMINO OCEAN Street</streetAddressLine>
+                    <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                    <county>Lah'mu</county>
+                    <city>Galactic City</city>
+                    <state>KZ</state>
+                    <postalCode>79572</postalCode>
+                    <country>AI</country>
+                </addr>
+            </providerOrganization>
+        </patientRole>
+    </recordTarget>
+    <author>
+        <time value="19850728232826-0600" />
+        <assignedAuthor>
+            <id root="2.16.840.1.113883.4.6" extension="XX13576542" />
+            <code code="208D00000X" codeSystem="2.16.840.1.113883.6.101"
+                displayName="General Practice Physician" />
+            <addr use="WP">
+                <streetAddressLine>54018 KAMINO OCEAN Spire</streetAddressLine>
+                <streetAddressLine>STE 820</streetAddressLine>
+                <city>Keren</city>
+                <state>YA</state>
+                <postalCode>81303</postalCode>
+            </addr>
+            <telecom use="WP" value="tel:+6-901-374-4286" />
+            <assignedPerson classCode="PSN" determinerCode="INSTANCE">
+                <name>
+                    <given>Elzar</given>
+                    <family>Baba</family>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="http://hl7.org/fhir/sid/us-npi" extension="XX22521268" />
+                <name>Academy of Agamar Research Institute</name>
+                <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                <addr use="WP">
+                    <streetAddressLine>554 KAMINO OCEAN Street</streetAddressLine>
+                    <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                    <county>Lah'mu</county>
+                    <city>Galactic City</city>
+                    <state>KZ</state>
+                    <postalCode>79572</postalCode>
+                    <country>AI</country>
+                </addr>
+            </representedOrganization>
+        </assignedAuthor>
+    </author>
+    <author>
+        <time value="19850728232826-0600" />
+        <assignedAuthor>
+            <id root="1.2.840.114350.1.1" extension="XX.6" />
+            <addr>
+                <streetAddressLine nullFlavor="UNK" />
+                <city nullFlavor="UNK" />
+                <state nullFlavor="UNK" />
+                <postalCode nullFlavor="UNK" />
+            </addr>
+            <telecom nullFlavor="NA" />
+            <assignedAuthoringDevice>
+                <manufacturerModelName>Epic - Version 11.3</manufacturerModelName>
+                <softwareName>Epic - Version 11.3</softwareName>
+            </assignedAuthoringDevice>
+            <representedOrganization>
+                <id root="http://hl7.org/fhir/sid/us-npi" extension="XX22521268" />
+                <name>Academy of Agamar Research Institute</name>
+                <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                <addr use="WP">
+                    <streetAddressLine>554 KAMINO OCEAN Street</streetAddressLine>
+                    <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                    <county>Lah'mu</county>
+                    <city>Galactic City</city>
+                    <state>KZ</state>
+                    <postalCode>79572</postalCode>
+                    <country>AI</country>
+                </addr>
+            </representedOrganization>
+        </assignedAuthor>
+    </author>
+    <custodian>
+        <assignedCustodian>
+            <representedCustodianOrganization>
+                <id root="http://hl7.org/fhir/sid/us-npi" extension="XX22521268" />
+                <name>Academy of Agamar Research Institute</name>
+                <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                <addr use="WP">
+                    <streetAddressLine>554 KAMINO OCEAN Street</streetAddressLine>
+                    <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                    <county>Lah'mu</county>
+                    <city>Galactic City</city>
+                    <state>KZ</state>
+                    <postalCode>79572</postalCode>
+                    <country>AI</country>
+                </addr>
+            </representedCustodianOrganization>
+        </assignedCustodian>
+    </custodian>
+    <componentOf>
+        <encompassingEncounter>
+            <id root="1.2.840.114350.1.13.4304.2.7.3.698084.8" extension="XX692" />
+            <code code="3" codeSystem="1.2.840.114350.1.72.1.30" displayName="Hospital Encounter">
+                <originalText>Hospital Encounter</originalText>
+                <translation code="0" codeSystem="1.2.840.114350.1.72.1.30.1" />
+            </code>
+            <effectiveTime>
+                <low value="19811016121446-0500" />
+            </effectiveTime>
+            <responsibleParty>
+                <assignedEntity>
+                    <id root="2.16.840.1.113883.4.6" extension="XX13576542" />
+                    <addr use="WP">
+                        <streetAddressLine>54018 KAMINO OCEAN Spire</streetAddressLine>
+                        <streetAddressLine>STE 820</streetAddressLine>
+                        <city>Keren</city>
+                        <state>YA</state>
+                        <postalCode>81303</postalCode>
+                    </addr>
+                    <telecom use="WP" value="tel:+6-901-374-4286" />
+                    <assignedPerson>
+                        <name>
+                            <given>Elzar</given>
+                            <family>Baba</family>
+                        </name>
+                    </assignedPerson>
+                    <representedOrganization>
+                        <name>Academy of Agamar Research Institute</name>
+                        <addr use="WP">
+                            <streetAddressLine>554 KAMINO OCEAN Street</streetAddressLine>
+                            <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                            <county>Lah'mu</county>
+                            <city>Galactic City</city>
+                            <state>KZ</state>
+                            <postalCode>79572</postalCode>
+                            <country>AI</country>
+                        </addr>
+                    </representedOrganization>
+                </assignedEntity>
+            </responsibleParty>
+            <encounterParticipant typeCode="ATND">
+                <time value="19811016121446-0500" />
+                <assignedEntity>
+                    <id root="2.16.840.1.113883.4.6" extension="1234561235" />
+                    <code code="208D00000X" codeSystem="2.16.840.1.113883.6.101"
+                        displayName="General Practice Physician">
+                        <originalText>Internal Medicine</originalText>
+                        <translation code="32" codeSystem="1.2.840.114350.1.72.1.7.7.10.688867.4160"
+                            codeSystemName="Epic.DXC.StandardProviderSpecialtyType"
+                            displayName="Internal Medicine" />
+                        <translation code="17"
+                            codeSystem="1.2.840.114350.1.13.4304.2.7.10.836982.1050"
+                            codeSystemName="Epic.SER.ProviderSpecialty"
+                            displayName="Internal Medicine" />
+                    </code>
+                    <addr use="WP">
+                        <streetAddressLine>90001 TEST Avey</streetAddressLine>
+                        <streetAddressLine>STE 100</streetAddressLine>
+                        <city>Washington</city>
+                        <state>DC</state>
+                        <postalCode>20000</postalCode>
+                    </addr>
+                    <telecom use="WP" value="tel:+1-608-271-9000" />
+                    <assignedPerson>
+                        <name use="L">
+                            <given>JohnTESTPROVIDER</given>
+                            <family>Powers</family>
+                            <suffix qualifier="AC"> MD</suffix>
+                        </name>
+                    </assignedPerson>
+                </assignedEntity>
+            </encounterParticipant>
+            <encounterParticipant typeCode="ADM">
+                <time value="19811016121446-0500" />
+                <assignedEntity>
+                    <id root="2.16.840.1.113883.4.6" extension="1234561235" />
+                    <code code="208D00000X" codeSystem="2.16.840.1.113883.6.101"
+                        displayName="General Practice Physician">
+                        <originalText>Internal Medicine</originalText>
+                        <translation code="32" codeSystem="1.2.840.114350.1.72.1.7.7.10.688867.4160"
+                            codeSystemName="Epic.DXC.StandardProviderSpecialtyType"
+                            displayName="Internal Medicine" />
+                        <translation code="17"
+                            codeSystem="1.2.840.114350.1.13.4304.2.7.10.836982.1050"
+                            codeSystemName="Epic.SER.ProviderSpecialty"
+                            displayName="Internal Medicine" />
+                    </code>
+                    <addr use="WP">
+                        <streetAddressLine>90001 TEST Avey</streetAddressLine>
+                        <streetAddressLine>STE 100</streetAddressLine>
+                        <city>Washington</city>
+                        <state>DC</state>
+                        <postalCode>20000</postalCode>
+                    </addr>
+                    <telecom use="WP" value="tel:+1-608-271-9000" />
+                    <assignedPerson>
+                        <name use="L">
+                            <given>JohnTESTPROVIDER</given>
+                            <family>Powers</family>
+                            <suffix qualifier="AC"> MD</suffix>
+                        </name>
+                    </assignedPerson>
+                </assignedEntity>
+            </encounterParticipant>
+            <location>
+                <healthCareFacility>
+                    <id root="1.2.840.114350.1.13.4304.2.7.2.686980" extension="XX114730" />
+                    <code code="1081-9" codeSystem="2.16.840.1.113883.6.259"
+                        displayName="Pediatric Medical-Surgical Ward">
+                        <originalText>Pediatrics</originalText>
+                        <translation code="82" codeSystem="1.2.840.114350.1.72.1.7.7.10.688867.4150"
+                            codeSystemName="Epic.DepartmentSpecialty" displayName="Pediatrics" />
+                    </code>
+                    <location>
+                        <name> Sissubo School Neighbourhood Laboratory</name>
+                        <addr use="WP">
+                            <streetAddressLine>4509 KAMINO OCEAN Street</streetAddressLine>
+                            <county>Lah'mu</county>
+                            <city>Galactic City</city>
+                            <state>KZ</state>
+                            <postalCode>89170-2785</postalCode>
+                            <country>AI</country>
+                        </addr>
+                    </location>
+                    <serviceProviderOrganization>
+                        <id root="1.2.840.114350.1.13.4304.2.7.2.696570" extension="XX7530" />
+                        <name>Institute of Takodana Neighbourhood Pharmacy &amp; Hospital</name>
+                        <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                        <addr use="WP">
+                            <streetAddressLine>554 KAMINO OCEAN Street</streetAddressLine>
+                            <county>Lah'mu</county>
+                            <city>Galactic City</city>
+                            <state>KZ</state>
+                            <postalCode>89170-2785</postalCode>
+                            <country>AI</country>
+                        </addr>
+                        <asOrganizationPartOf>
+                            <wholeOrganization>
+                                <name>Academy of Agamar Research Institute</name>
+                                <addr use="WP">
+                                    <streetAddressLine>554 KAMINO OCEAN Street</streetAddressLine>
+                                    <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                                    <county>Lah'mu</county>
+                                    <city>Galactic City</city>
+                                    <state>KZ</state>
+                                    <postalCode>79572</postalCode>
+                                    <country>AI</country>
+                                </addr>
+                            </wholeOrganization>
+                        </asOrganizationPartOf>
+                    </serviceProviderOrganization>
+                </healthCareFacility>
+            </location>
+        </encompassingEncounter>
+    </componentOf>
+    <component>
+        <structuredBody>
+            <component>
+                <section>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.4" />
+                    <code code="10164-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="HISTORY OF PRESENT ILLNESS" />
+                    <title>Miscellaneous Notes</title>
+                    <text>
+                        <list styleCode="xTOC">
+                            <item>
+                                <caption>REMOVED</caption>
+                                <content ID="Note2">
+                                    <content>
+                                        <content styleCode="xLabel">REMOVED.</content>
+											<br />REMOVED </content>
+                                    <br />
+                                    <content styleCode="xLabel">REMOVED</content>
+                                    <br />
+                                </content>
+                            </item>
+                            <item>
+                                <caption>REMOVED</caption>
+                                <content ID="Note3">
+                                    <content>
+                                        <content styleCode="xLabel">REMOVED.</content>
+											<br />REMOVED </content>
+                                    <br />
+                                    <content styleCode="xLabel">REMOVED</content>
+                                    <br />
+                                </content>
+                            </item>
+                        </list>
+                        <footnote ID="subTitle1" styleCode="xSectionSubTitle">documented in this
+                            encounter</footnote>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2" extension="2015-08-01" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2.1" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2.1" extension="2015-08-01" />
+                    <id root="366CAB00-DA66-11EF-B655-005056BE2511" />
+                    <code code="11369-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="History of Immunization Narrative" />
+                    <title>Immunizations</title>
+                    <text>
+                        <table>
+                            <colgroup>
+                                <col width="25%" />
+                                <col width="50%" />
+                                <col width="25%" />
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Immunization</th>
+                                    <th>Administration Dates</th>
+                                    <th>Next Due</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr ID="immunization6">
+                                    <td ID="immunization6Name">REMOVED</td>
+                                    <td>
+                                        <content>REMOVED</content>
+                                    </td>
+                                    <td />
+                                </tr>
+                            </tbody>
+                        </table>
+                        <footnote ID="subTitle5" styleCode="xSectionSubTitle">documented as of this
+                            encounter</footnote>
+                    </text>
+                    <entry>
+                        <substanceAdministration classCode="SBADM" moodCode="EVN"
+                            negationInd="false">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"
+                                extension="2015-08-01" />
+                            <id root="1.2.840.114350.1.13.4304.2.7.2.768076" extension="XX291" />
+                            <code code="IMMUNIZ" codeSystem="2.16.840.1.113883.5.4"
+                                codeSystemName="ActCode" />
+                            <text>
+                                <reference value="#immunization6" />
+                            </text>
+                            <statusCode code="completed" />
+                            <effectiveTime value="19811015" />
+                            <doseQuantity unit="mL" value=".5" />
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"
+                                        extension="2014-06-09" />
+                                    <manufacturedMaterial>
+                                        <code nullFlavor="OTH">
+                                            <originalText>
+                                                <reference value="#immunization6Name" />
+                                            </originalText>
+                                            <translation code="49281-400-10"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC" />
+                                        </code>
+                                        <lotNumberText>651414</lotNumberText>
+                                    </manufacturedMaterial>
+                                    <manufacturerOrganization>
+                                        <name>Sanofi Pasteur</name>
+                                    </manufacturerOrganization>
+                                </manufacturedProduct>
+                            </consumable>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id root="2.16.840.1.113883.4.6" extension="XX13576542" />
+                                    <code code="208D00000X" codeSystem="2.16.840.1.113883.6.101"
+                                        displayName="General Practice Physician">
+                                        <originalText>Internal Medicine</originalText>
+                                        <translation code="32"
+                                            codeSystem="1.2.840.114350.1.72.1.7.7.10.688867.4160"
+                                            codeSystemName="Epic.DXC.StandardProviderSpecialtyType"
+                                            displayName="Internal Medicine" />
+                                        <translation code="17"
+                                            codeSystem="1.2.840.114350.1.13.4304.2.7.10.836982.1050"
+                                            codeSystemName="Epic.SER.ProviderSpecialty"
+                                            displayName="Internal Medicine" />
+                                    </code>
+                                    <addr use="WP">
+                                        <streetAddressLine>54018 KAMINO OCEAN Spire</streetAddressLine>
+                                        <streetAddressLine>STE 820</streetAddressLine>
+                                        <city>Keren</city>
+                                        <state>YA</state>
+                                        <postalCode>81303</postalCode>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+6-901-374-4286" />
+                                    <assignedPerson>
+                                        <name>
+                                            <given>Elzar</given>
+                                            <family>Baba</family>
+                                            <suffix qualifier="AC">MD</suffix>
+                                        </name>
+                                    </assignedPerson>
+                                </assignedEntity>
+                            </performer>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01" />
+                                <time value="19811016122946-0500" />
+                                <assignedAuthor>
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.1133"
+                                        extension="XX6050978" />
+                                    <id root="2.16.840.1.113883.4.6" extension="XX13576542" />
+                                    <code code="208D00000X" codeSystem="2.16.840.1.113883.6.101"
+                                        displayName="General Practice Physician">
+                                        <originalText>Internal Medicine</originalText>
+                                        <translation code="32"
+                                            codeSystem="1.2.840.114350.1.72.1.7.7.10.688867.4160"
+                                            codeSystemName="Epic.DXC.StandardProviderSpecialtyType"
+                                            displayName="Internal Medicine" />
+                                        <translation code="17"
+                                            codeSystem="1.2.840.114350.1.13.4304.2.7.10.836982.1050"
+                                            codeSystemName="Epic.SER.ProviderSpecialty"
+                                            displayName="Internal Medicine" />
+                                    </code>
+                                    <addr use="WP">
+                                        <streetAddressLine>54018 KAMINO OCEAN Spire</streetAddressLine>
+                                        <streetAddressLine>STE 820</streetAddressLine>
+                                        <city>Keren</city>
+                                        <state>YA</state>
+                                        <postalCode>81303</postalCode>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+6-901-374-4286" />
+                                    <representedOrganization>
+                                        <id root="http://hl7.org/fhir/sid/us-npi"
+                                            extension="XX22521268" />
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK" />
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                        <name>Academy of Agamar Research Institute</name>
+                                        <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                                        <addr use="WP">
+                                            <streetAddressLine>554 KAMINO OCEAN Street</streetAddressLine>
+                                            <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                                            <county>Lah'mu</county>
+                                            <city>Galactic City</city>
+                                            <state>KZ</state>
+                                            <postalCode>79572</postalCode>
+                                            <country>AI</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </substanceAdministration>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.38" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.38" extension="2014-06-09" />
+                    <id root="368CF1FF-DA66-11EF-B655-005056BE2511" />
+                    <code code="29549-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="MEDICATIONS ADMINISTERED" />
+                    <title>Administered Medications</title>
+                    <text>
+                        <table ID="admMedTable10">
+                            <caption>REMOVED</caption>
+                            <colgroup>
+                                <col width="40%" />
+                                <col width="10%" span="6" />
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>REMOVED</th>
+                                    <th>REMOVED</th>
+                                    <th>REMOVED</th>
+                                    <th>Dose</th>
+                                    <th>REMOVED</th>
+                                    <th>REMOVED</th>
+                                    <th>REMOVED</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr styleCode="xRowNormal xmedRow">
+                                    <td rowspan="1" styleCode="Rrule">
+                                        <paragraph ID="med7">removed</paragraph>
+                                        <paragraph ID="sig7" styleCode="xIndent">REMOVED</paragraph>
+                                        <content styleCode="xallIndent">REMOVED <content
+                                                ID="indication8">Cleft hard
+                                                palate</content>
+                                        </content>
+                                    </td>
+                                    <td>REMOVED</td>
+                                    <td>REMOVED</td>
+                                    <td>removed</td>
+                                    <td />
+                                    <td />
+                                    <td />
+                                </tr>
+                                <tr styleCode="xRowNormal xMergeUp">
+                                    <td styleCode="Rrule" />
+                                    <td colspan="6" />
+                                </tr>
+                            </tbody>
+                        </table>
+                        <footnote ID="subTitle9" styleCode="xSectionSubTitle">documented in this
+                            encounter</footnote>
+                    </text>
+                    <entry>
+                        <substanceAdministration classCode="SBADM" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09" />
+                            <id root="1.2.840.114350.1.13.4304.2.7.2.798268" extension="XX86340" />
+                            <text>
+                                <reference value="#sig7" />
+                            </text>
+                            <statusCode code="active" />
+                            <effectiveTime xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                xsi:type="IVL_TS">
+                                <low value="19811016173114+0000" />
+                            </effectiveTime>
+                            <effectiveTime xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                xsi:type="PIVL_TS" institutionSpecified="false" operator="A">
+                                <period unit="h" value="6" />
+                            </effectiveTime>
+                            <routeCode code="C38288" codeSystem="2.16.840.1.113883.3.26.1.1"
+                                codeSystemName="NCI Thesaurus" displayName="Oral">
+                                <originalText>Oral</originalText>
+                            </routeCode>
+                            <doseQuantity unit="mg/kg" value="10" />
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09" />
+                                    <manufacturedMaterial>
+                                        <code code="197803" codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#med7" />
+                                            </originalText>
+                                            <translation code="0363-0897-26"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC" />
+                                            <translation code="27912"
+                                                codeSystem="2.16.840.1.113883.6.253"
+                                                codeSystemName="Medispan Drug Descriptor ID" />
+                                            <translation code="66100020001820"
+                                                codeSystem="2.16.840.1.113883.6.68"
+                                                codeSystemName="Medi-Span Generic Product Identifier" />
+                                            <translation code="27912"
+                                                codeSystem="2.16.840.1.113883.6.162"
+                                                codeSystemName="Med-File (Medi-Span)" />
+                                        </code>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id root="2.16.840.1.113883.4.6" extension="XX13576542" />
+                                    <code code="208D00000X" codeSystem="2.16.840.1.113883.6.101"
+                                        displayName="General Practice Physician">
+                                        <originalText>Internal Medicine</originalText>
+                                        <translation code="32"
+                                            codeSystem="1.2.840.114350.1.72.1.7.7.10.688867.4160"
+                                            codeSystemName="Epic.DXC.StandardProviderSpecialtyType"
+                                            displayName="Internal Medicine" />
+                                        <translation code="17"
+                                            codeSystem="1.2.840.114350.1.13.4304.2.7.10.836982.1050"
+                                            codeSystemName="Epic.SER.ProviderSpecialty"
+                                            displayName="Internal Medicine" />
+                                    </code>
+                                    <addr use="WP">
+                                        <streetAddressLine>54018 KAMINO OCEAN Spire</streetAddressLine>
+                                        <streetAddressLine>STE 820</streetAddressLine>
+                                        <city>Keren</city>
+                                        <state>YA</state>
+                                        <postalCode>81303</postalCode>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+6-901-374-4286" />
+                                    <assignedPerson>
+                                        <name>
+                                            <given>Elzar</given>
+                                            <family>Baba</family>
+                                            <suffix qualifier="AC">MD</suffix>
+                                        </name>
+                                    </assignedPerson>
+                                </assignedEntity>
+                            </performer>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01" />
+                                <time value="19811016123301-0500" />
+                                <assignedAuthor>
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.1133"
+                                        extension="XX6050978" />
+                                    <id root="2.16.840.1.113883.4.6" extension="XX13576542" />
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2023-05-01" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.6.798268.180"
+                                        extension="XX22854.4" />
+                                    <code code="282291009" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" />
+                                    <text>Cleft hard palate <reference value="#indication8" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        code="749.00" codeSystem="2.16.840.1.113883.6.103"
+                                        codeSystemName="ICD9" xsi:type="CD" />
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01" />
+                                        <time value="19811016123301-0500" />
+                                        <assignedAuthor>
+                                            <id root="1.2.840.114350.1.13.4304.2.7.1.1133"
+                                                extension="XX6050978" />
+                                            <id root="2.16.840.1.113883.4.6" extension="XX13576542" />
+                                        </assignedAuthor>
+                                    </author>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="REFR">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.1.47" />
+                                    <code code="33999-4" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC" displayName="Status" />
+                                    <statusCode code="completed" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        code="55561003" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CE"
+                                        displayName="Active" />
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.118" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.2055.1"
+                                        extension="XX38859.59583" />
+                                    <code code="416118004" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" />
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="19811016173146+0000" />
+                                </act>
+                            </entryRelationship>
+                            <precondition typeCode="PRCN">
+                                <criterion>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.25" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.25"
+                                        extension="2014-06-09" />
+                                    <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="CD" nullFlavor="OTH">
+                                        <originalText>REMOVED</originalText>
+                                    </value>
+                                </criterion>
+                            </precondition>
+                        </substanceAdministration>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.10" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.10" extension="2014-06-09" />
+                    <code code="18776-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="Plan of care note" />
+                    <title>Plan of Treatment</title>
+                    <text>
+                        <table>
+                            <caption>REMOVED</caption>
+                            <colgroup>
+                                <col width="10%" />
+                                <col width="15%" />
+                                <col width="25%" span="3" />
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Type</th>
+                                    <th>Department</th>
+                                    <th>REMOVED</th>
+                                    <th>Description</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr ID="encounter12" styleCode="xRowNormal">
+                                    <td>REMOVED</td>
+                                    <td ID="encounter12type">REMOVED</td>
+                                    <td>
+                                        <paragraph>REMOVED</paragraph>
+                                        <paragraph>REMOVED</paragraph>
+                                        <paragraph>REMOVED</paragraph>
+                                        <paragraph>608-271-9000</paragraph>
+                                    </td>
+                                    <td>
+                                        <paragraph styleCode="Bold">REMOVED</paragraph>
+                                        <paragraph>REMOVED</paragraph>
+                                        <paragraph>REMOVED</paragraph>
+                                        <paragraph>REMOVED</paragraph>
+                                    </td>
+                                    <td />
+                                </tr>
+                            </tbody>
+                        </table>
+                        <footnote ID="subTitle11" styleCode="xSectionSubTitle">documented as of this
+                            encounter</footnote>
+                    </text>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.40" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.40"
+                                extension="2014-06-09" />
+                            <id assigningAuthorityName="EPIC"
+                                root="1.2.840.114350.1.13.4304.2.7.3.698084.8" extension="XX887" />
+                            <code code="AMB" codeSystem="2.16.840.1.113883.5.4">
+                                <originalText>
+                                    <reference value="#encounter12type" />
+                                </originalText>
+                                <translation code="101"
+                                    codeSystem="1.2.840.114350.1.13.4304.2.7.4.698084.30"
+                                    codeSystemName="Epic.EncounterType" />
+                                <translation code="101" codeSystem="1.2.840.114350.1.72.1.30" />
+                                <translation code="4" codeSystem="1.2.840.114350.1.72.1.30.1" />
+                            </code>
+                            <text>
+                                <reference value="#encounter12" />
+                            </text>
+                            <statusCode code="active" />
+                            <effectiveTime>
+                                <low value="19851015" />
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <time>
+                                    <low nullFlavor="UNK" />
+                                    <high nullFlavor="UNK" />
+                                </time>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id root="2.16.840.1.113883.4.6" extension="XX22521268" />
+                                    <code code="208D00000X" codeSystem="2.16.840.1.113883.6.101"
+                                        displayName="General Practice Physician">
+                                        <originalText>Family Medicine</originalText>
+                                        <translation code="19"
+                                            codeSystem="1.2.840.114350.1.72.1.7.7.10.688867.4160"
+                                            codeSystemName="Epic.DXC.StandardProviderSpecialtyType"
+                                            displayName="Family Medicine" />
+                                        <translation code="9"
+                                            codeSystem="1.2.840.114350.1.13.4304.2.7.10.836982.1050"
+                                            codeSystemName="Epic.SER.ProviderSpecialty"
+                                            displayName="Family Medicine" />
+                                    </code>
+                                    <addr use="WP">
+                                        <streetAddressLine>554 KAMINO OCEAN Street</streetAddressLine>
+                                        <city>Galactic City</city>
+                                        <state>KZ</state>
+                                        <postalCode>21672</postalCode>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+6-901-374-4286" />
+                                    <assignedPerson>
+                                        <name>
+                                            <given>Karis</given>
+                                            <family>Lona</family>
+                                            <suffix qualifier="AC">MD</suffix>
+                                        </name>
+                                    </assignedPerson>
+                                </assignedEntity>
+                            </performer>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01" />
+                                <time value="19811016124921-0500" />
+                                <assignedAuthor>
+                                    <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                    <telecom nullFlavor="UNK" />
+                                    <representedOrganization>
+                                        <id root="http://hl7.org/fhir/sid/us-npi"
+                                            extension="XX22521268" />
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK" />
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                        <name>Academy of Agamar Research Institute</name>
+                                        <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                                        <addr use="WP">
+                                            <streetAddressLine>554 KAMINO OCEAN Street</streetAddressLine>
+                                            <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                                            <county>Lah'mu</county>
+                                            <city>Galactic City</city>
+                                            <state>KZ</state>
+                                            <postalCode>79572</postalCode>
+                                            <country>AI</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.2.686980"
+                                        extension="XX534260" />
+                                    <code nullFlavor="UNK">
+                                        <originalText>Family Medicine</originalText>
+                                        <translation code="19"
+                                            codeSystem="1.2.840.114350.1.72.1.7.7.10.688867.4150"
+                                            codeSystemName="Epic.DepartmentSpecialty"
+                                            displayName="Family Medicine" />
+                                    </code>
+                                    <addr use="WP">
+                                        <streetAddressLine>554 KAMINO OCEAN Street</streetAddressLine>
+                                        <county>Lah'mu</county>
+                                        <city>Galactic City</city>
+                                        <state>KZ</state>
+                                        <postalCode>89170-2785</postalCode>
+                                        <country>AI</country>
+                                    </addr>
+                                    <playingEntity classCode="PLC">
+                                        <name>University Medical Center &amp; Pharmacy of Ando</name>
+                                        <desc>Family Medicine</desc>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                        </encounter>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5" extension="2015-08-01" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1" extension="2015-08-01" />
+                    <id root="3697709E-DA66-11EF-B655-005056BE2511" />
+                    <code code="11450-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="Problem list - Reported" />
+                    <title>Active Problems</title>
+                    <text>
+                        <table>
+                            <colgroup>
+                                <col width="60%" />
+                                <col width="15%" />
+                                <col width="25%" />
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Problem</th>
+                                    <th>Noted Date</th>
+                                    <th>REMOVED</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr ID="problem16" styleCode="xRowNormal">
+                                    <td ID="problem16name">Zika virus disease</td>
+                                    <td>REMOVED</td>
+                                    <td />
+                                </tr>
+                                <tr ID="problem15" styleCode="xRowAlt">
+                                    <td ID="problem15name">Cleft hard palate</td>
+                                    <td>REMOVED</td>
+                                    <td />
+                                </tr>
+                            </tbody>
+                        </table>
+                        <footnote ID="subTitle14" styleCode="xSectionSubTitle">removed</footnote>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01" />
+                            <id root="1.2.840.114350.1.13.4304.2.7.2.768076"
+                                extension="xx442-xjxbnva" />
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass" displayName="Concern" />
+                            <text>
+                                <reference value="#problem15" />
+                            </text>
+                            <statusCode code="active" />
+                            <effectiveTime>
+                                <low value="19811016" />
+                            </effectiveTime>
+                            <entryRelationship typeCode="SUBJ" inversionInd="false">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2022-06-01" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.2.768076"
+                                        extension="XX091" />
+                                    <code code="64572001" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75323-6"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC" />
+                                    </code>
+                                    <text>
+                                        <reference value="#problem15name" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime>
+                                        <low value="19811015" />
+                                    </effectiveTime>
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        code="448915004" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#problem15name" />
+                                        </originalText>
+                                        <translation code="Q35.1"
+                                            codeSystem="2.16.840.1.113883.6.90"
+                                            codeSystemName="ICD10" displayName="Cleft hard palate" />
+                                        <translation code="749.00"
+                                            codeSystem="2.16.840.1.113883.6.103"
+                                            codeSystemName="ICD9" displayName="Cleft hard palate" />
+                                        <translation code="745491"
+                                            codeSystem="2.16.840.1.113883.3.247.1.1"
+                                            codeSystemName="Intelligent Medical Objects ProblemIT"
+                                            displayName="Cleft hard palate" />
+                                    </value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01" />
+                                        <time value="19811017004309-0500" />
+                                        <assignedAuthor>
+                                            <id root="1.2.840.114350.1.13.4304.2.7.1.1133"
+                                                extension="XX6050978" />
+                                            <id root="2.16.840.1.113883.4.6" extension="XX13576542" />
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6" />
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20" />
+                                            <code code="33999-4" codeSystem="2.16.840.1.113883.6.1"
+                                                displayName="Status" />
+                                            <statusCode code="completed" />
+                                            <effectiveTime>
+                                                <low value="19811015" />
+                                            </effectiveTime>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                code="55561003" codeSystem="2.16.840.1.113883.6.96"
+                                                xsi:type="CD" displayName="Active" />
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01" />
+                            <id root="1.2.840.114350.1.13.4304.2.7.2.768076"
+                                extension="xx569-zawxzpg" />
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass" displayName="Concern" />
+                            <text>
+                                <reference value="#problem16" />
+                            </text>
+                            <statusCode code="active" />
+                            <effectiveTime>
+                                <low value="19850728" />
+                            </effectiveTime>
+                            <entryRelationship typeCode="SUBJ" inversionInd="false">
+                                <observation classCode="OBS" moodCode="EVN" negationInd="false">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2022-06-01" />
+                                    <templateId root="2.16.840.1.113883.10.20.15.2.3.3"
+                                        extension="2016-12-01" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.2.768076"
+                                        extension="XX381" />
+                                    <code code="64572001" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75323-6"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC" />
+                                    </code>
+                                    <text>
+                                        <reference value="#problem16name" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime>
+                                        <low value="19850728" />
+                                    </effectiveTime>
+                                    <value xmlns:sdtc="urn:hl7-org:sdtc"
+                                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        code="3928002" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"
+                                        sdtc:valueSet="2.16.840.1.114222.4.11.7508"
+                                        sdtc:valueSetVersion="3/29/2022">
+                                        <originalText>
+                                            <reference value="#problem16name" />
+                                        </originalText>
+                                        <translation code="A92.5"
+                                            codeSystem="2.16.840.1.113883.6.90"
+                                            codeSystemName="ICD10" displayName="Zika virus disease" />
+                                        <translation code="066.3"
+                                            codeSystem="2.16.840.1.113883.6.103"
+                                            codeSystemName="ICD9" displayName="Zika virus disease" />
+                                        <translation code="25447"
+                                            codeSystem="2.16.840.1.113883.3.247.1.1"
+                                            codeSystemName="Intelligent Medical Objects ProblemIT"
+                                            displayName="Zika virus disease" />
+                                    </value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01" />
+                                        <time value="19850728232732-0600" />
+                                        <assignedAuthor>
+                                            <id root="1.2.840.114350.1.13.4304.2.7.1.1133"
+                                                extension="XX6050978" />
+                                            <id root="2.16.840.1.113883.4.6" extension="XX13576542" />
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6" />
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20" />
+                                            <code code="33999-4" codeSystem="2.16.840.1.113883.6.1"
+                                                displayName="Status" />
+                                            <statusCode code="completed" />
+                                            <effectiveTime>
+                                                <low value="19850728" />
+                                            </effectiveTime>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                code="55561003" codeSystem="2.16.840.1.113883.6.96"
+                                                xsi:type="CD" displayName="Active" />
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1" />
+                    <id root="36989282-da66-11ef-b655-005056be2511" />
+                    <code code="10154-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="CHIEF COMPLAINT" />
+                    <title>Chief Complaint</title>
+                    <text>REMOVED </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3" extension="2015-08-01" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3.1" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3.1" extension="2015-08-01" />
+                    <id root="36A3CB85-DA66-11EF-B655-005056BE2511" />
+                    <code code="30954-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="Relevant diagnostic tests/laboratory data Narrative" />
+                    <title>Results</title>
+                    <text>
+                        <list styleCode="xTOC">
+                            <item ID="Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603">
+                                <caption
+                                    ID="Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Procedure">
+                                    REMOVED</caption>
+                                <table>
+                                    <colgroup>
+                                        <col width="20%" />
+                                        <col width="12%" />
+                                        <col width="8%" />
+                                        <col width="20%" />
+                                        <col width="10%" span="2" />
+                                        <col width="20%" />
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th>Component</th>
+                                            <th>Value</th>
+                                            <th>Ref Range</th>
+                                            <th>Test Method</th>
+                                            <th>Analysis Time</th>
+                                            <th>Performed At</th>
+                                            <th>Pathologist Signature</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp1"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp1Name">
+                                                REMOVED</td>
+                                            <td>12</td>
+                                            <td>REMOVED</td>
+                                            <td />
+                                            <td />
+                                            <td />
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp1Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp2"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp2Name">
+                                                WBC</td>
+                                            <td>REMOVED</td>
+                                            <td>REMOVED</td>
+                                            <td />
+                                            <td />
+                                            <td />
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp2Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp3"
+                                            styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp3Name">
+                                                PLT</td>
+                                            <td>300</td>
+                                            <td>REMOVED</td>
+                                            <td />
+                                            <td />
+                                            <td />
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp3Signature" />
+                                        </tr>
+                                        <tr
+                                            ID="Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp4"
+                                            styleCode="xRowAlt">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp4Name">
+                                                REMOVED</td>
+                                            <td>5</td>
+                                            <td>REMOVED</td>
+                                            <td />
+                                            <td />
+                                            <td />
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp4Signature" />
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                <table>
+                                    <colgroup>
+                                        <col width="20%" span="5" />
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th>REMOVED</th>
+                                            <th>REMOVED</th>
+                                            <th>REMOVED</th>
+                                            <th>REMOVED</th>
+                                            <th>REMOVED</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr styleCode="xRowNormal">
+                                            <td
+                                                ID="Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Specimen">
+                                                Blood</td>
+                                            <td>REMOVED</td>
+                                            <td />
+                                            <td>REMOVED</td>
+                                            <td />
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                <table>
+                                    <thead>
+                                        <tr>
+                                            <th>Narrative</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td styleCode="xpre">
+                                                <paragraph />
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                <table>
+                                    <colgroup>
+                                        <col width="20%" span="2" />
+                                        <col width="60%" />
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th>Authorizing Provider</th>
+                                            <th>Result Type</th>
+                                            <th>REMOVED</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>REMOVED</td>
+                                            <td>REMOVED</td>
+                                            <td>REMOVED</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </item>
+                        </list>
+                        <footnote ID="subTitle17" styleCode="xSectionSubTitle">documented in this
+                            encounter</footnote>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="BATTERY" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2015-08-01" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2023-05-01" />
+                            <id root="1.2.840.114350.1.13.4304.2.7.2.798268" extension="XX97036" />
+                            <code code="58410-2" codeSystem="2.16.840.1.113883.6.1"
+                                codeSystemName="LOINC">
+                                <originalText>CBC</originalText>
+                                <translation code="1698"
+                                    codeSystem="1.2.840.114350.1.13.4304.2.7.2.696580"
+                                    codeSystemName="Epic.EAP.ID" displayName="CBC" />
+                            </code>
+                            <sdtc:text xmlns:sdtc="urn:hl7-org:sdtc">
+                                <reference
+                                    value="#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603" />
+                            </sdtc:text>
+                            <statusCode code="completed" />
+                            <effectiveTime>
+                                <low value="19811016" />
+                                <high value="19811016" />
+                            </effectiveTime>
+                            <specimen typeCode="SPC">
+                                <specimenRole classCode="SPEC">
+                                    <id root="1.2.840.114350.1.13.4304.2.7.7.798268.300"
+                                        extension="XX97036" />
+                                    <specimenPlayingEntity>
+                                        <code code="119297000" codeSystem="2.16.840.1.113883.6.96"
+                                            codeSystemName="SNOMED CT">
+                                            <originalText>Blood</originalText>
+                                            <translation code="3"
+                                                codeSystem="1.2.840.114350.1.13.4304.2.7.4.798268.300"
+                                                codeSystemName="Epic.Specimen" displayName="Blood" />
+                                        </code>
+                                    </specimenPlayingEntity>
+                                </specimenRole>
+                            </specimen>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01" />
+                                <time value="19811018003509-0500" />
+                                <assignedAuthor>
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.1133"
+                                        extension="XX6050978" />
+                                    <id root="2.16.840.1.113883.4.6" extension="XX13576542" />
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.2.840.114350.1.13.4304.2.7.3.688879.110"
+                                        extension="XXa:QVXU:CA:Ycv64" />
+                                    <representedOrganization>
+                                        <name>Jakku Regional Clinic + Pharmacy</name>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <participant typeCode="RESP">
+                                <participantRole classCode="PROV">
+                                    <id root="2.16.840.1.113883.4.6" extension="XX13576542" />
+                                    <code code="208D00000X" codeSystem="2.16.840.1.113883.6.101"
+                                        displayName="General Practice Physician">
+                                        <originalText>Internal Medicine</originalText>
+                                        <translation code="32"
+                                            codeSystem="1.2.840.114350.1.72.1.7.7.10.688867.4160"
+                                            codeSystemName="Epic.DXC.StandardProviderSpecialtyType"
+                                            displayName="Internal Medicine" />
+                                        <translation code="17"
+                                            codeSystem="1.2.840.114350.1.13.4304.2.7.10.836982.1050"
+                                            codeSystemName="Epic.SER.ProviderSpecialty"
+                                            displayName="Internal Medicine" />
+                                    </code>
+                                    <addr use="WP">
+                                        <streetAddressLine>54018 KAMINO OCEAN Spire</streetAddressLine>
+                                        <streetAddressLine>STE 820</streetAddressLine>
+                                        <city>Keren</city>
+                                        <state>YA</state>
+                                        <postalCode>81303</postalCode>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+6-901-374-4286" />
+                                    <playingEntity classCode="PSN">
+                                        <name use="L">
+                                            <given>Elzar</given>
+                                            <family>Baba</family>
+                                            <suffix qualifier="AC"> MD</suffix>
+                                        </name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <component>
+                                <procedure classCode="PROC" moodCode="EVN">
+                                    <code code="17636008" codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"
+                                        displayName="Specimen collection (procedure)" />
+                                    <effectiveTime nullFlavor="UNK" />
+                                    <targetSiteCode code="122555007"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"
+                                        displayName="Venous blood specimen (specimen)">
+                                        <translation code="310"
+                                            codeSystem="1.2.840.114350.1.13.4304.2.7.4.798268.325"
+                                            codeSystemName="Epic.Specimen"
+                                            displayName="Blood, Venous" />
+                                    </targetSiteCode>
+                                    <participant typeCode="PRD">
+                                        <templateId root="1.2.840.114350.1.72.3.12" />
+                                        <participantRole classCode="SPEC">
+                                            <id root="1.2.840.114350.1.13.4304.2.7.7.798268.300"
+                                                extension="XX97036" />
+                                            <playingEntity>
+                                                <code code="119297000"
+                                                    codeSystem="2.16.840.1.113883.6.96"
+                                                    codeSystemName="SNOMED CT">
+                                                    <originalText>Blood</originalText>
+                                                    <translation code="3"
+                                                        codeSystem="1.2.840.114350.1.13.4304.2.7.4.798268.300"
+                                                        codeSystemName="Epic.Specimen"
+                                                        displayName="Blood" />
+                                                </code>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </procedure>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.6.798268.2000"
+                                        extension="XX27262.4" />
+                                    <code code="30313-1" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>REMOVED<reference
+                                                value="#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp1Name" />
+                                        </originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp1" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="19811018053346+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="PQ" unit="g/dL" value="12" />
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.6.798268.2000"
+                                        extension="XX44824.7" />
+                                    <code code="33765-9" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>REMOVED<reference
+                                                value="#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp2Name" />
+                                        </originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp2" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="19811018053346+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="PQ" unit="10*3/uL" value="10000" />
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>REMOVED</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="IVL_PQ">
+                                                <low nullFlavor="UNK" />
+                                                <high value="500000" unit="10*3/uL" />
+                                            </value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.6.798268.2000"
+                                        extension="XX20053.5" />
+                                    <code code="26515-7" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>REMOVED<reference
+                                                value="#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp3Name" />
+                                        </originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp3" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="19811018053346+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="PQ" unit="10*3/uL" value="300" />
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.6.798268.2000"
+                                        extension="XX98970.7" />
+                                    <code code="50544-6" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>REMOVED<reference
+                                                value="#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp4Name" />
+                                        </originalText>
+                                    </code>
+                                    <text>
+                                        <reference
+                                            value="#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp4" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="19811018053346+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="PQ" unit="ng/mL" value="5" />
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>REMOVED</text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="IVL_PQ">
+                                                <low value="2" unit="ng/mL" />
+                                                <high value="8" unit="ng/mL" />
+                                            </value>
+                                            <interpretationCode code="N"
+                                                codeSystem="2.16.840.1.113883.5.83" />
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="1.2.840.114350.1.72.3.4" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.2.798268"
+                                        extension="XX97036" />
+                                    <code nullFlavor="UNK" />
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="19811018053346+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        code="12" codeSystem="1.2.840.114350.1.72.1.5007"
+                                        codeSystemName="Epic.Result.Type" xsi:type="CD" />
+                                </observation>
+                            </component>
+                            <component typeCode="COMP">
+                                <procedure classCode="PROC" moodCode="EVN">
+                                    <entryRelationship typeCode="COMP" inversionInd="true">
+                                        <act classCode="ACT" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.122" />
+                                            <id root="1.2.840.114350.1.13.4304.2.7.1.1988.1"
+                                                extension="XX28196-5493" />
+                                            <code nullFlavor="NP" />
+                                            <statusCode code="completed" />
+                                        </act>
+                                    </entryRelationship>
+                                </procedure>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.17" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.17" extension="2015-08-01" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.17" extension="2020-09-01" />
+                    <code code="29762-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="Social history Narrative" />
+                    <title>Social History</title>
+                    <text>
+                        <table ID="sochist19">
+                            <colgroup>
+                                <col width="25%" span="2" />
+                                <col width="13%" />
+                                <col width="12%" />
+                                <col width="25%" />
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Tobacco Use</th>
+                                    <th>Types</th>
+                                    <th>Packs/Day</th>
+                                    <th>Years Used</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>Smoking Tobacco: Never</td>
+                                    <td />
+                                    <td ID="sochist19packsperday" />
+                                    <td />
+                                    <td />
+                                </tr>
+                                <tr ID="sochist19smokeless" styleCode="xRowAlt">
+                                    <td>REMOVED</td>
+                                    <td />
+                                    <td />
+                                    <td />
+                                    <td />
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table>
+                            <colgroup>
+                                <col width="25%" span="2" />
+                                <col width="50%" />
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Alcohol Use</th>
+                                    <th>Standard Drinks/Week</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td ID="alcoholStatus">Never</td>
+                                    <td>removed</td>
+                                    <td />
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table>
+                            <colgroup>
+                                <col width="50%" />
+                                <col width="25%" span="2" />
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>REMOVED</th>
+                                    <th>Value</th>
+                                    <th>Date Recorded</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr ID="BirthSex22">
+                                    <td>Sex Assigned at Birth</td>
+                                    <td ID="BirthSex22Value">Male</td>
+                                    <td>REMOVED</td>
+                                </tr>
+                                <tr ID="LegalSex23">
+                                    <td>REMOVED</td>
+                                    <td ID="LegalSex23Value">Male</td>
+                                    <td>REMOVED</td>
+                                </tr>
+                                <tr ID="GenderIdentity20">
+                                    <td>Gender Identity</td>
+                                    <td ID="GenderIdentity20Value">Not on file</td>
+                                    <td />
+                                </tr>
+                                <tr ID="SexualOrientation21">
+                                    <td>Sexual Orientation</td>
+                                    <td ID="SexualOrientation21Value">Not on file</td>
+                                    <td />
+                                </tr>
+                            </tbody>
+                        </table>
+                        <footnote ID="subTitle18" styleCode="xSectionSubTitle">documented as of this
+                            encounter</footnote>
+                    </text>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"
+                                extension="2014-06-09" />
+                            <id root="1.2.840.114350.1.13.4304.2.7.1.1040.1"
+                                extension="XX075^^78581-6" />
+                            <code code="72166-2" codeSystem="2.16.840.1.113883.6.1"
+                                codeSystemName="LOINC" displayName="Tobacco smoking status NHIS" />
+                            <text>
+                                <reference value="#sochist19" />
+                            </text>
+                            <statusCode code="completed" />
+                            <effectiveTime value="19811015" />
+                            <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                code="266919005" codeSystem="2.16.840.1.113883.6.96"
+                                codeSystemName="SNOMED CT" xsi:type="CD"
+                                displayName="Never smoked tobacco" />
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01" />
+                                <time value="19811015" />
+                                <assignedAuthor>
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.1133"
+                                        extension="XX6050978" />
+                                    <id root="2.16.840.1.113883.4.6" extension="XX13576542" />
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01" />
+                            <id root="1.2.840.114350.1.13.4304.2.7.1.1040.8"
+                                extension="XX370^^645891606" />
+                            <code code="229819007" codeSystem="2.16.840.1.113883.6.96"
+                                codeSystemName="SNOMED-CT" displayName="Tobacco use and exposure">
+                                <translation code="88031-0" codeSystem="2.16.840.1.113883.6.1"
+                                    codeSystemName="LOINC" displayName="Smokeless tobacco status" />
+                            </code>
+                            <text>
+                                <reference value="#sochist19smokeless" />
+                            </text>
+                            <statusCode code="completed" />
+                            <effectiveTime value="19811015" />
+                            <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                code="451381000124107" codeSystem="2.16.840.1.113883.6.96"
+                                codeSystemName="SNOMED CT" xsi:type="CD"
+                                displayName="Smokeless tobacco non-user" />
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01" />
+                                <time value="19811015" />
+                                <assignedAuthor>
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.1133"
+                                        extension="XX6050978" />
+                                    <id root="2.16.840.1.113883.4.6" extension="XX13576542" />
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01" />
+                            <id root="1.2.840.114350.1.13.4304.2.7.1.1040.12"
+                                extension="XX241^78523.05^009290342" />
+                            <code code="897148007" codeSystem="2.16.840.1.113883.6.96"
+                                codeSystemName="SNOMED CT" displayName="Alcoholic beverage intake">
+                                <translation code="11331-6" codeSystem="2.16.840.1.113883.6.1"
+                                    codeSystemName="LOINC" displayName="History of Alcohol Use" />
+                            </code>
+                            <statusCode code="completed" />
+                            <effectiveTime value="19811015" />
+                            <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                code="228274009" codeSystem="2.16.840.1.113883.6.96"
+                                codeSystemName="SNOMED CT" xsi:type="CD"
+                                displayName="Lifetime non-drinker (finding)">
+                                <originalText>
+                                    <reference value="#alcoholStatus" />
+                                </originalText>
+                            </value>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2022-06-01" />
+                            <id root="1.2.840.114350.1.13.4304.2.7.1.1040.21"
+                                extension="XX81066525-12694-V8612" />
+                            <code code="8689-2" codeSystem="2.16.840.1.113883.6.1"
+                                codeSystemName="LOINC" displayName="History of Social function" />
+                            <statusCode code="completed" />
+                            <effectiveTime value="19811015" />
+                            <entryRelationship typeCode="SPRT">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.69" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.69"
+                                        extension="2022-06-01" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.83687972"
+                                        extension="XX81066525-12694-V8612" />
+                                    <code code="88028-6" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC" displayName="Tobacco use panel">
+                                        <originalText>REMOVED</originalText>
+                                    </code>
+                                    <text>
+                                        <reference nullFlavor="UNK" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="19811015" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="CD" nullFlavor="UNK" />
+                                    <interpretationCode nullFlavor="OTH">
+                                        <originalText>Low Risk </originalText>
+                                        <translation code="X-SDOH-RISK-1"
+                                            codeSystem="1.2.840.114350.1.72.1.8.1"
+                                            codeSystemName="Epic.Sdoh" displayName="Low Risk " />
+                                    </interpretationCode>
+                                    <entryRelationship typeCode="COMP">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.86" />
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.86"
+                                                extension="2022-06-01" />
+                                            <id root="1.2.840.114350.1.13.4304.2.7.1.83687972"
+                                                extension="XXs87752-3307835746-22913-A7141" />
+                                            <code code="72166-2" codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"
+                                                displayName="Tobacco smoking status NHIS">
+                                                <originalText>REMOVED</originalText>
+                                            </code>
+                                            <statusCode code="completed" />
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                code="LA18978-9" codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC" xsi:type="CD"
+                                                displayName="Never smoker">
+                                                <originalText>REMOVED</originalText>
+                                                <translation code="266919005"
+                                                    codeSystem="2.16.840.1.113883.6.96"
+                                                    codeSystemName="SNOMED CT"
+                                                    displayName="Never smoked tobacco (finding)" />
+                                            </value>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="COMP">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.86" />
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.86"
+                                                extension="2022-06-01" />
+                                            <id root="1.2.840.114350.1.13.4304.2.7.1.83687972"
+                                                extension="XXv45901-4417680455-49616-D1737" />
+                                            <code code="88031-0" codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"
+                                                displayName="Smokeless tobacco status">
+                                                <originalText>REMOVED</originalText>
+                                            </code>
+                                            <statusCode code="completed" />
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                code="LA4519-0" codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC" xsi:type="CD"
+                                                displayName="Never used">
+                                                <originalText>REMOVED</originalText>
+                                                <translation code="228502006"
+                                                    codeSystem="2.16.840.1.113883.6.96"
+                                                    codeSystemName="SNOMED CT"
+                                                    displayName="Never used moist powdered tobacco (finding)" />
+                                            </value>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="COMP">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.86" />
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.86"
+                                                extension="2022-06-01" />
+                                            <id root="1.2.840.114350.1.13.4304.2.7.1.83687972"
+                                                extension="XXh66838-3936872386-73162-X0893" />
+                                            <code nullFlavor="UNK">
+                                                <originalText>REMOVED</originalText>
+                                            </code>
+                                            <statusCode code="completed" />
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="CD" nullFlavor="OTH">
+                                                <originalText>Not on file</originalText>
+                                            </value>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.200"
+                                extension="2016-06-01" />
+                            <id root="1.2.840.114350.1.13.4304.2.7.1.1040.20" extension="XX998" />
+                            <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                                codeSystemName="LOINC" displayName="Sex assigned at birth" />
+                            <text>
+                                <reference value="#BirthSex22" />
+                            </text>
+                            <statusCode code="completed" />
+                            <effectiveTime value="18601014" />
+                            <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" code="M"
+                                codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7 Gender"
+                                xsi:type="CD">
+                                <originalText>
+                                    <reference value="#BirthSex22Value" />
+                                </originalText>
+                            </value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01" />
+                                <time value="19811018002301-0500" />
+                                <assignedAuthor>
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.1133"
+                                        extension="XX6050978" />
+                                    <id root="2.16.840.1.113883.4.6" extension="XX13576542" />
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2022-06-01" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.507"
+                                extension="2023-06-28" />
+                            <id root="1.2.840.114350.1.13.4304.2.7.1.1040.23"
+                                extension="XX091^94923^77831-5" />
+                            <code code="46098-0" codeSystem="2.16.840.1.113883.6.1"
+                                codeSystemName="LOINC" displayName="Sex" />
+                            <text>
+                                <reference value="#LegalSex23" />
+                            </text>
+                            <statusCode code="completed" />
+                            <effectiveTime value="19811016120932-0500" />
+                            <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                code="248153007" codeSystem="2.16.840.1.113883.6.96"
+                                codeSystemName="SNOMEDCT" xsi:type="CD" displayName="Male (finding)">
+                                <originalText>
+                                    <reference value="#LegalSex23Value" />
+                                </originalText>
+                            </value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01" />
+                                <time value="19811016120932-0500" />
+                                <assignedAuthor>
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.1133"
+                                        extension="XX6050978" />
+                                    <id root="2.16.840.1.113883.4.6" extension="XX13576542" />
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.34.3.45"
+                                extension="2022-06-01" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01" />
+                            <id root="1.2.840.114350.1.13.4304.2.7.1.1040.46" extension="XX998" />
+                            <code code="76691-5" codeSystem="2.16.840.1.113883.6.1"
+                                codeSystemName="LOINC" displayName="Gender identity" />
+                            <text>
+                                <reference value="#GenderIdentity20" />
+                            </text>
+                            <statusCode code="completed" />
+                            <effectiveTime>
+                                <low nullFlavor="UNK" />
+                            </effectiveTime>
+                            <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                xsi:type="CD" nullFlavor="UNK">
+                                <originalText>
+                                    <reference value="#GenderIdentity20Value" />
+                                </originalText>
+                            </value>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.501"
+                                extension="2022-06-01" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01" />
+                            <id root="1.2.840.114350.1.13.4304.2.7.1.1040.45" extension="XX546.9" />
+                            <code code="76690-7" codeSystem="2.16.840.1.113883.6.1"
+                                codeSystemName="LOINC" displayName="Sexual orientation" />
+                            <text>
+                                <reference value="#SexualOrientation21" />
+                            </text>
+                            <statusCode code="completed" />
+                            <effectiveTime>
+                                <low nullFlavor="UNK" />
+                            </effectiveTime>
+                            <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                xsi:type="CD" nullFlavor="UNK">
+                                <originalText>
+                                    <reference value="#SexualOrientation21Value" />
+                                </originalText>
+                            </value>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.4" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.4" extension="2015-08-01" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.4.1" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.4.1" extension="2015-08-01" />
+                    <code code="8716-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="Vital signs" />
+                    <title>Last Filed Vital Signs</title>
+                    <text>
+                        <table>
+                            <colgroup>
+                                <col width="25%" span="4" />
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Vital Sign</th>
+                                    <th>REMOVED</th>
+                                    <th>REMOVED</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr styleCode="xRowNormal">
+                                    <td styleCode="xcellHeader">REMOVED</td>
+                                    <td>
+                                        <content ID="sysBP_5689278360">90</content>/ <content
+                                            ID="diaBP_5689278360">50</content>
+                                    </td>
+                                    <td>REMOVED</td>
+                                    <td />
+                                </tr>
+                                <tr ID="pulse_5689278360" styleCode="xRowAlt">
+                                    <td styleCode="xcellHeader">Pulse</td>
+                                    <td>80</td>
+                                    <td>REMOVED</td>
+                                    <td />
+                                </tr>
+                                <tr ID="temp_5689278360" styleCode="xRowNormal">
+                                    <td styleCode="xcellHeader">REMOVED</td>
+                                    <td>REMOVED</td>
+                                    <td>REMOVED</td>
+                                    <td />
+                                </tr>
+                                <tr ID="resp_5689278360" styleCode="xRowAlt">
+                                    <td styleCode="xcellHeader">REMOVED</td>
+                                    <td>20</td>
+                                    <td>REMOVED</td>
+                                    <td />
+                                </tr>
+                                <tr ID="SpO2_" styleCode="xRowNormal">
+                                    <td styleCode="xcellHeader">REMOVED</td>
+                                    <td>-</td>
+                                    <td>-</td>
+                                    <td />
+                                </tr>
+                                <tr ID="inhaled_" styleCode="xRowAlt">
+                                    <td styleCode="xcellHeader">REMOVED</td>
+                                    <td>-</td>
+                                    <td>-</td>
+                                    <td />
+                                </tr>
+                                <tr ID="weight_5689278360" styleCode="xRowNormal">
+                                    <td styleCode="xcellHeader">Weight</td>
+                                    <td>removed</td>
+                                    <td>REMOVED</td>
+                                    <td />
+                                </tr>
+                                <tr ID="height_5689278360" styleCode="xRowAlt">
+                                    <td styleCode="xcellHeader">Height</td>
+                                    <td>removed</td>
+                                    <td>REMOVED</td>
+                                    <td />
+                                </tr>
+                                <tr ID="wflPerc_5689278360" styleCode="xRowNormal">
+                                    <td styleCode="xcellHeader">REMOVED</td>
+                                    <td>REMOVED</td>
+                                    <td>REMOVED</td>
+                                    <td />
+                                </tr>
+                                <tr styleCode="xRowNormal xmergeUp">
+                                    <td colspan="4">
+                                        <content ID="wflPerc5689278360GCSource4" styleCode="xIndent">
+                                            REMOVED</content>
+                                    </td>
+                                </tr>
+                                <tr ID="circum_5689278360" styleCode="xRowAlt">
+                                    <td styleCode="xcellHeader">Head Circumference</td>
+                                    <td>removed</td>
+                                    <td>REMOVED</td>
+                                    <td />
+                                </tr>
+                                <tr ID="circumPerc_5689278360" styleCode="xRowNormal">
+                                    <td styleCode="xcellHeader">REMOVED</td>
+                                    <td>REMOVED</td>
+                                    <td>REMOVED</td>
+                                    <td />
+                                </tr>
+                                <tr styleCode="xRowNormal xmergeUp">
+                                    <td colspan="4">
+                                        <content ID="circumPerc5689278360GCSource2"
+                                            styleCode="xIndent">REMOVED</content>
+                                    </td>
+                                </tr>
+                                <tr ID="bmi_5689278360" styleCode="xRowAlt">
+                                    <td styleCode="xcellHeader">REMOVED</td>
+                                    <td>17.17</td>
+                                    <td>REMOVED</td>
+                                    <td />
+                                </tr>
+                                <tr ID="bmiPerc_5689278360" styleCode="xRowNormal">
+                                    <td styleCode="xcellHeader">REMOVED</td>
+                                    <td>REMOVED</td>
+                                    <td>REMOVED</td>
+                                    <td />
+                                </tr>
+                                <tr styleCode="xRowNormal xmergeUp">
+                                    <td colspan="4">
+                                        <content ID="bmiPerc5689278360GCSource4" styleCode="xIndent">
+                                            REMOVED</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <footnote ID="subTitle24" styleCode="xSectionSubTitle">documented in this
+                            encounter</footnote>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                                extension="2015-08-01" />
+                            <id root="1.2.840.114350.1.13.4304.2.7.1.2109"
+                                extension="XX70857029-Z8605" />
+                            <code code="46680005" codeSystem="2.16.840.1.113883.6.96"
+                                codeSystemName="SNOMED CT" displayName="Vital signs">
+                                <translation code="74728-7" codeSystem="2.16.840.1.113883.6.1"
+                                    codeSystemName="LOINC"
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel - HL7.CCDAr1.1" />
+                            </code>
+                            <statusCode code="completed" />
+                            <effectiveTime value="19811016171746+0000" />
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.2109.1"
+                                        extension="XX83411565-lpaFA-L5523" />
+                                    <code code="8480-6" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>REMOVED</originalText>
+                                    </code>
+                                    <text>
+                                        <reference value="#sysBP_5689278360" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="19811016171746+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="PQ" unit="mm[Hg]" value="90" />
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01" />
+                                        <time value="19811016122203-0500" />
+                                        <assignedAuthor>
+                                            <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                            <telecom nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <id root="http://hl7.org/fhir/sid/us-npi"
+                                                    extension="XX22521268" />
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK" />
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                                <name>Academy of Agamar Research Institute</name>
+                                                <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                                                <addr use="WP">
+                                                    <streetAddressLine>554 KAMINO OCEAN
+                                                        St.</streetAddressLine>
+                                                    <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                                                    <county>Lah'mu</county>
+                                                    <city>Galactic City</city>
+                                                    <state>KZ</state>
+                                                    <postalCode>79572</postalCode>
+                                                    <country>AI</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.2109.1"
+                                        extension="XX40890395-ozmWP-Y2671" />
+                                    <code code="8462-4" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>REMOVED</originalText>
+                                    </code>
+                                    <text>
+                                        <reference value="#diaBP_5689278360" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="19811016171746+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="PQ" unit="mm[Hg]" value="50" />
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01" />
+                                        <time value="19811016122203-0500" />
+                                        <assignedAuthor>
+                                            <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                            <telecom nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <id root="http://hl7.org/fhir/sid/us-npi"
+                                                    extension="XX22521268" />
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK" />
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                                <name>Academy of Agamar Research Institute</name>
+                                                <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                                                <addr use="WP">
+                                                    <streetAddressLine>554 KAMINO OCEAN
+                                                        St.</streetAddressLine>
+                                                    <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                                                    <county>Lah'mu</county>
+                                                    <city>Galactic City</city>
+                                                    <state>KZ</state>
+                                                    <postalCode>79572</postalCode>
+                                                    <country>AI</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.2109.1"
+                                        extension="XX01506024-cjolx-L3283" />
+                                    <code code="8867-4" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>REMOVED</originalText>
+                                    </code>
+                                    <text>
+                                        <reference value="#pulse_5689278360" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="19811016171746+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="PQ" unit="/min" value="80" />
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01" />
+                                        <time value="19811016122203-0500" />
+                                        <assignedAuthor>
+                                            <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                            <telecom nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <id root="http://hl7.org/fhir/sid/us-npi"
+                                                    extension="XX22521268" />
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK" />
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                                <name>Academy of Agamar Research Institute</name>
+                                                <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                                                <addr use="WP">
+                                                    <streetAddressLine>554 KAMINO OCEAN
+                                                        St.</streetAddressLine>
+                                                    <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                                                    <county>Lah'mu</county>
+                                                    <city>Galactic City</city>
+                                                    <state>KZ</state>
+                                                    <postalCode>79572</postalCode>
+                                                    <country>AI</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.2109.1"
+                                        extension="XX88375515-dgkvC86-M2951" />
+                                    <code code="8310-5" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>REMOVED</originalText>
+                                    </code>
+                                    <text>
+                                        <reference value="#temp_5689278360" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="19811016171746+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="PQ" unit="Cel" value="36.67" />
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01" />
+                                        <time value="19811016122203-0500" />
+                                        <assignedAuthor>
+                                            <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                            <telecom nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <id root="http://hl7.org/fhir/sid/us-npi"
+                                                    extension="XX22521268" />
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK" />
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                                <name>Academy of Agamar Research Institute</name>
+                                                <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                                                <addr use="WP">
+                                                    <streetAddressLine>554 KAMINO OCEAN
+                                                        St.</streetAddressLine>
+                                                    <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                                                    <county>Lah'mu</county>
+                                                    <city>Galactic City</city>
+                                                    <state>KZ</state>
+                                                    <postalCode>79572</postalCode>
+                                                    <country>AI</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.2109.1"
+                                        extension="XX26130336-sotr-Q1844" />
+                                    <code code="9279-1" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>REMOVED</originalText>
+                                    </code>
+                                    <text>
+                                        <reference value="#resp_5689278360" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="19811016171746+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="PQ" unit="/min" value="20" />
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01" />
+                                        <time value="19811016122203-0500" />
+                                        <assignedAuthor>
+                                            <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                            <telecom nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <id root="http://hl7.org/fhir/sid/us-npi"
+                                                    extension="XX22521268" />
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK" />
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                                <name>Academy of Agamar Research Institute</name>
+                                                <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                                                <addr use="WP">
+                                                    <streetAddressLine>554 KAMINO OCEAN
+                                                        St.</streetAddressLine>
+                                                    <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                                                    <county>Lah'mu</county>
+                                                    <city>Galactic City</city>
+                                                    <state>KZ</state>
+                                                    <postalCode>79572</postalCode>
+                                                    <country>AI</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.2109.1"
+                                        extension="XX26228197-kzqefkL58-L8864" />
+                                    <code code="8302-2" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>REMOVED</originalText>
+                                    </code>
+                                    <text>
+                                        <reference value="#height_5689278360" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="19811016171746+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="PQ" unit="cm" value="89" />
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01" />
+                                        <time value="19811016122203-0500" />
+                                        <assignedAuthor>
+                                            <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                            <telecom nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <id root="http://hl7.org/fhir/sid/us-npi"
+                                                    extension="XX22521268" />
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK" />
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                                <name>Academy of Agamar Research Institute</name>
+                                                <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                                                <addr use="WP">
+                                                    <streetAddressLine>554 KAMINO OCEAN
+                                                        St.</streetAddressLine>
+                                                    <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                                                    <county>Lah'mu</county>
+                                                    <city>Galactic City</city>
+                                                    <state>KZ</state>
+                                                    <postalCode>79572</postalCode>
+                                                    <country>AI</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.2109.1"
+                                        extension="XX91590139-vxsffhN64-V7319" />
+                                    <code code="29463-7" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>REMOVED</originalText>
+                                    </code>
+                                    <text>
+                                        <reference value="#weight_5689278360" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="19811016171746+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="PQ" unit="kg" value="13.6" />
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01" />
+                                        <time value="19811016122203-0500" />
+                                        <assignedAuthor>
+                                            <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                            <telecom nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <id root="http://hl7.org/fhir/sid/us-npi"
+                                                    extension="XX22521268" />
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK" />
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                                <name>Academy of Agamar Research Institute</name>
+                                                <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                                                <addr use="WP">
+                                                    <streetAddressLine>554 KAMINO OCEAN
+                                                        St.</streetAddressLine>
+                                                    <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                                                    <county>Lah'mu</county>
+                                                    <city>Galactic City</city>
+                                                    <state>KZ</state>
+                                                    <postalCode>79572</postalCode>
+                                                    <country>AI</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.2109.1"
+                                        extension="XX14930537-kzn-J7801" />
+                                    <code code="39156-5" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>REMOVED</originalText>
+                                    </code>
+                                    <text>
+                                        <reference value="#bmi_5689278360" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="19811016171746+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="PQ" unit="kg/m2" value="17.17" />
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01" />
+                                        <time value="19811016122203-0500" />
+                                        <assignedAuthor>
+                                            <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                            <telecom nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <id root="http://hl7.org/fhir/sid/us-npi"
+                                                    extension="XX22521268" />
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK" />
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                                <name>Academy of Agamar Research Institute</name>
+                                                <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                                                <addr use="WP">
+                                                    <streetAddressLine>554 KAMINO OCEAN
+                                                        St.</streetAddressLine>
+                                                    <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                                                    <county>Lah'mu</county>
+                                                    <city>Galactic City</city>
+                                                    <state>KZ</state>
+                                                    <postalCode>79572</postalCode>
+                                                    <country>AI</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.2109.1"
+                                        extension="XX70448418-ljzGvadV37-G8750" />
+                                    <code code="59576-9" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>REMOVED</originalText>
+                                    </code>
+                                    <text>
+                                        <reference value="#bmiPerc_5689278360" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="19811016171746+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="PQ" unit="%" value="66.39" />
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01" />
+                                        <time value="19811016122203-0500" />
+                                        <assignedAuthor>
+                                            <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                            <telecom nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <id root="http://hl7.org/fhir/sid/us-npi"
+                                                    extension="XX22521268" />
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK" />
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                                <name>Academy of Agamar Research Institute</name>
+                                                <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                                                <addr use="WP">
+                                                    <streetAddressLine>554 KAMINO OCEAN
+                                                        St.</streetAddressLine>
+                                                    <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                                                    <county>Lah'mu</county>
+                                                    <city>Galactic City</city>
+                                                    <state>KZ</state>
+                                                    <postalCode>79572</postalCode>
+                                                    <country>AI</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>REMOVED<reference
+                                                    value="#bmiPerc5689278360GCSource4" />
+                                            </text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ED">REMOVED<reference
+                                                    value="#bmiPerc5689278360GCSource4" />
+                                            </value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.2109.1"
+                                        extension="XX31403220-bpqpcpI46-Z5266" />
+                                    <code code="8287-5" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>REMOVED</originalText>
+                                    </code>
+                                    <text>
+                                        <reference value="#circum_5689278360" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="19811016171746+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="PQ" unit="cm" value="50" />
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01" />
+                                        <time value="19811016122203-0500" />
+                                        <assignedAuthor>
+                                            <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                            <telecom nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <id root="http://hl7.org/fhir/sid/us-npi"
+                                                    extension="XX22521268" />
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK" />
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                                <name>Academy of Agamar Research Institute</name>
+                                                <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                                                <addr use="WP">
+                                                    <streetAddressLine>554 KAMINO OCEAN
+                                                        St.</streetAddressLine>
+                                                    <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                                                    <county>Lah'mu</county>
+                                                    <city>Galactic City</city>
+                                                    <state>KZ</state>
+                                                    <postalCode>79572</postalCode>
+                                                    <country>AI</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.2109.1"
+                                        extension="XX88973478-xhnrlfJismB42-F6112" />
+                                    <code code="8289-1" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>REMOVED</originalText>
+                                    </code>
+                                    <text>
+                                        <reference value="#circumPerc_5689278360" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="19811016171746+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="PQ" unit="%" value="82.86" />
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01" />
+                                        <time value="19811016122203-0500" />
+                                        <assignedAuthor>
+                                            <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                            <telecom nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <id root="http://hl7.org/fhir/sid/us-npi"
+                                                    extension="XX22521268" />
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK" />
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                                <name>Academy of Agamar Research Institute</name>
+                                                <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                                                <addr use="WP">
+                                                    <streetAddressLine>554 KAMINO OCEAN
+                                                        St.</streetAddressLine>
+                                                    <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                                                    <county>Lah'mu</county>
+                                                    <city>Galactic City</city>
+                                                    <state>KZ</state>
+                                                    <postalCode>79572</postalCode>
+                                                    <country>AI</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>REMOVED<reference
+                                                    value="#circumPerc5689278360GCSource2" />
+                                            </text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ED">REMOVED<reference
+                                                    value="#circumPerc5689278360GCSource2" />
+                                            </value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.2109.1"
+                                        extension="XX99551761-csxTnxoD10-R3044" />
+                                    <code code="77606-2" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC">
+                                        <originalText>REMOVED</originalText>
+                                    </code>
+                                    <text>
+                                        <reference value="#wflPerc_5689278360" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                    <effectiveTime value="19811016171746+0000" />
+                                    <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        xsi:type="PQ" unit="%" value="72.23" />
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01" />
+                                        <time value="19811016122203-0500" />
+                                        <assignedAuthor>
+                                            <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                            <telecom nullFlavor="UNK" />
+                                            <representedOrganization>
+                                                <id root="http://hl7.org/fhir/sid/us-npi"
+                                                    extension="XX22521268" />
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK" />
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                                <name>Academy of Agamar Research Institute</name>
+                                                <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                                                <addr use="WP">
+                                                    <streetAddressLine>554 KAMINO OCEAN
+                                                        St.</streetAddressLine>
+                                                    <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                                                    <county>Lah'mu</county>
+                                                    <city>Galactic City</city>
+                                                    <state>KZ</state>
+                                                    <postalCode>79572</postalCode>
+                                                    <country>AI</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>REMOVED<reference
+                                                    value="#wflPerc5689278360GCSource4" />
+                                            </text>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                xsi:type="ED">REMOVED<reference
+                                                    value="#wflPerc5689278360GCSource4" />
+                                            </value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.7" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.7" extension="2014-06-09" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.7.1" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.7.1" extension="2014-06-09" />
+                    <id root="36C02380-DA66-11EF-B655-005056BE2511" />
+                    <code code="47519-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="History of Procedures Document" />
+                    <title>Procedures</title>
+                    <text>
+                        <list>
+                            <item>
+                                <content styleCode="xAlert">REMOVED.</content>
+                            </item>
+                        </list>
+                        <br />
+                        <table>
+                            <colgroup>
+                                <col width="25%" />
+                                <col width="10%" />
+                                <col width="15%" />
+                                <col width="25%" span="2" />
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>REMOVED</th>
+                                    <th>REMOVED</th>
+                                    <th>Date/Time</th>
+                                    <th>REMOVED</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr ID="procedure27" styleCode="xRowNormal">
+                                    <td>
+                                        <content ID="procedure27name">CBC</content>
+                                    </td>
+                                    <td>Routine</td>
+                                    <td>REMOVED</td>
+                                    <td />
+                                    <td>
+                                        <paragraph styleCode="Bold">REMOVED <content
+                                                styleCode="xLink2-Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603">
+                                            removed</content>. </paragraph>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <footnote ID="subTitle26" styleCode="xSectionSubTitle">documented in this
+                            encounter</footnote>
+                    </text>
+                    <entry>
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09" />
+                            <id root="1.2.840.114350.1.13.4304.2.7.1.1988.1"
+                                extension="XX28196-5493" />
+                            <code code="58410-2" codeSystem="2.16.840.1.113883.6.1"
+                                codeSystemName="LOINC">
+                                <originalText>CBC <reference value="#procedure27name" />
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#procedure27" />
+                            </text>
+                            <statusCode code="completed" />
+                            <effectiveTime value="19811016" />
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id root="2.16.840.1.113883.4.6" extension="XX13576542" />
+                                    <code code="208D00000X" codeSystem="2.16.840.1.113883.6.101"
+                                        displayName="General Practice Physician">
+                                        <originalText>Internal Medicine</originalText>
+                                        <translation code="32"
+                                            codeSystem="1.2.840.114350.1.72.1.7.7.10.688867.4160"
+                                            codeSystemName="Epic.DXC.StandardProviderSpecialtyType"
+                                            displayName="Internal Medicine" />
+                                        <translation code="17"
+                                            codeSystem="1.2.840.114350.1.13.4304.2.7.10.836982.1050"
+                                            codeSystemName="Epic.SER.ProviderSpecialty"
+                                            displayName="Internal Medicine" />
+                                    </code>
+                                    <addr use="WP">
+                                        <streetAddressLine>54018 KAMINO OCEAN Spire</streetAddressLine>
+                                        <streetAddressLine>STE 820</streetAddressLine>
+                                        <city>Keren</city>
+                                        <state>YA</state>
+                                        <postalCode>81303</postalCode>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+6-901-374-4286" />
+                                    <assignedPerson>
+                                        <name>
+                                            <given>Elzar</given>
+                                            <family>Baba</family>
+                                            <suffix qualifier="AC">MD</suffix>
+                                        </name>
+                                    </assignedPerson>
+                                </assignedEntity>
+                            </performer>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01" />
+                                <time value="19811017003437-0500" />
+                                <assignedAuthor>
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.1133"
+                                        extension="XX6050978" />
+                                    <id root="2.16.840.1.113883.4.6" extension="XX13576542" />
+                                </assignedAuthor>
+                            </author>
+                        </procedure>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.43" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.43" extension="2015-08-01" />
+                    <id root="36C0CA42-DA66-11EF-B655-005056BE2511" />
+                    <code code="46241-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="Hospital admission diagnosis Narrative - Reported">
+                        <translation code="42347-5" codeSystem="2.16.840.1.113883.6.1"
+                            codeSystemName="LOINC" displayName="Admission diagnosis (narrative)" />
+                    </code>
+                    <title>Admitting Diagnoses</title>
+                    <text>
+                        <content ID="nof31">Not on file</content>
+                        <footnote ID="subTitle30" styleCode="xSectionSubTitle">documented in this
+                            encounter</footnote>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.12" />
+                    <code code="29299-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="REASON FOR VISIT" />
+                    <title>Reason for Visit</title>
+                    <text>
+                        <list>
+                            <item>
+                                <table>
+                                    <colgroup>
+                                        <col width="25%" />
+                                        <col width="75%" />
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th>Reason</th>
+                                            <th>Comments</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr ID="rfv33">
+                                            <td ID="reasonrfv33">REMOVED</td>
+                                            <td />
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </item>
+                        </list>
+                    </text>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="1.2.840.114350.1.72.7" />
+                            <id root="1.2.840.114350.1.13.4304.2.7.2.728286"
+                                extension="XXS-406-83132-4" />
+                            <code code="8661-1" codeSystem="2.16.840.1.113883.6.1"
+                                codeSystemName="LOINC" displayName="Chief Complaint" />
+                            <statusCode code="completed" />
+                            <effectiveTime nullFlavor="UNK" />
+                            <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                xsi:type="CD" nullFlavor="UNK">
+                                <originalText>REMOVED</originalText>
+                            </value>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.1" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.1" extension="2014-06-09" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.1.1" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.1.1" extension="2014-06-09" />
+                    <id root="36C1EC28-DA66-11EF-B655-005056BE2511" />
+                    <code code="10160-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="History of Medication use Narrative" />
+                    <title>Medications</title>
+                    <text>
+                        <content ID="nof35">Not on file</content>
+                        <footnote ID="subTitle34" styleCode="xSectionSubTitle">removed</footnote>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22" extension="2015-08-01" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22.1" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22.1" extension="2015-08-01" />
+                    <code code="46240-8" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="History of Hospitalizations+Outpatient visits Narrative" />
+                    <title>Encounter Details</title>
+                    <text>
+                        <table>
+                            <colgroup>
+                                <col width="10%" />
+                                <col width="15%" />
+                                <col width="25%" span="3" />
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Type</th>
+                                    <th>Department</th>
+                                    <th>REMOVED</th>
+                                    <th>Description</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr ID="encounter36" styleCode="xRowNormal">
+                                    <td>REMOVED</td>
+                                    <td ID="encounter36type">REMOVED</td>
+                                    <td>
+                                        <paragraph>REMOVED</paragraph>
+                                        <paragraph>REMOVED</paragraph>
+                                        <paragraph>REMOVED</paragraph>
+                                        <paragraph>608-271-9000</paragraph>
+                                    </td>
+                                    <td>
+                                        <paragraph styleCode="Bold">REMOVED</paragraph>
+                                        <paragraph>REMOVED</paragraph>
+                                        <paragraph>REMOVED</paragraph>
+                                        <paragraph>REMOVED</paragraph>
+                                        <paragraph>REMOVED</paragraph>
+                                    </td>
+                                    <td>
+                                        <content ID="encounter36desc">REMOVED</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49" />
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01" />
+                            <id assigningAuthorityName="EPIC"
+                                root="1.2.840.114350.1.13.4304.2.7.3.698084.8" extension="XX692" />
+                            <code code="AMB" codeSystem="2.16.840.1.113883.5.4">
+                                <originalText>
+                                    <reference value="#encounter36type" />
+                                </originalText>
+                                <translation code="3"
+                                    codeSystem="1.2.840.114350.1.13.4304.2.7.4.698084.30"
+                                    codeSystemName="Epic.EncounterType" />
+                                <translation code="3" codeSystem="1.2.840.114350.1.72.1.30" />
+                                <translation code="0" codeSystem="1.2.840.114350.1.72.1.30.1" />
+                            </code>
+                            <text>
+                                <reference value="#encounter36" />
+                            </text>
+                            <statusCode code="normal" />
+                            <effectiveTime>
+                                <low value="19811016121446-0500" />
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <time>
+                                    <low nullFlavor="UNK" />
+                                    <high nullFlavor="UNK" />
+                                </time>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id root="2.16.840.1.113883.4.6" extension="XX13576542" />
+                                    <code code="208D00000X" codeSystem="2.16.840.1.113883.6.101"
+                                        displayName="General Practice Physician">
+                                        <originalText>Internal Medicine</originalText>
+                                        <translation code="32"
+                                            codeSystem="1.2.840.114350.1.72.1.7.7.10.688867.4160"
+                                            codeSystemName="Epic.DXC.StandardProviderSpecialtyType"
+                                            displayName="Internal Medicine" />
+                                        <translation code="17"
+                                            codeSystem="1.2.840.114350.1.13.4304.2.7.10.836982.1050"
+                                            codeSystemName="Epic.SER.ProviderSpecialty"
+                                            displayName="Internal Medicine" />
+                                    </code>
+                                    <addr use="WP">
+                                        <streetAddressLine>54018 KAMINO OCEAN Spire</streetAddressLine>
+                                        <streetAddressLine>STE 820</streetAddressLine>
+                                        <city>Keren</city>
+                                        <state>YA</state>
+                                        <postalCode>81303</postalCode>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+6-901-374-4286" />
+                                    <assignedPerson>
+                                        <name>
+                                            <given>Elzar</given>
+                                            <family>Baba</family>
+                                            <suffix qualifier="AC">MD</suffix>
+                                        </name>
+                                    </assignedPerson>
+                                </assignedEntity>
+                            </performer>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01" />
+                                <time value="19811016121100-0500" />
+                                <assignedAuthor>
+                                    <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                    <telecom nullFlavor="UNK" />
+                                    <representedOrganization>
+                                        <id root="http://hl7.org/fhir/sid/us-npi"
+                                            extension="XX22521268" />
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK" />
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK" />
+                                        <name>Academy of Agamar Research Institute</name>
+                                        <telecom use="WP" value="tel:+3-298-900-4460-y60" />
+                                        <addr use="WP">
+                                            <streetAddressLine>554 KAMINO OCEAN Street</streetAddressLine>
+                                            <streetAddressLine>Building SubaddressIdentifier</streetAddressLine>
+                                            <county>Lah'mu</county>
+                                            <city>Galactic City</city>
+                                            <state>KZ</state>
+                                            <postalCode>79572</postalCode>
+                                            <country>AI</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.2.686980"
+                                        extension="XX114730" />
+                                    <code code="1081-9" codeSystem="2.16.840.1.113883.6.259"
+                                        displayName="Pediatric Medical-Surgical Ward">
+                                        <originalText>Pediatrics</originalText>
+                                        <translation code="82"
+                                            codeSystem="1.2.840.114350.1.72.1.7.7.10.688867.4150"
+                                            codeSystemName="Epic.DepartmentSpecialty"
+                                            displayName="Pediatrics" />
+                                    </code>
+                                    <addr use="WP">
+                                        <streetAddressLine>554 KAMINO OCEAN Street</streetAddressLine>
+                                        <county>Lah'mu</county>
+                                        <city>Galactic City</city>
+                                        <state>KZ</state>
+                                        <postalCode>89170-2785</postalCode>
+                                        <country>AI</country>
+                                    </addr>
+                                    <playingEntity classCode="PLC">
+                                        <name>College Laboratory and Hospital of Sullust</name>
+                                        <desc>Pediatrics</desc>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="COMP">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.64" />
+                                    <code code="48767-8" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC" />
+                                    <text>
+                                        <reference value="#encounter36desc" />
+                                    </text>
+                                    <statusCode code="completed" />
+                                </act>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.1099.1"
+                                        extension="xx887-856560-mapypdh" />
+                                    <code code="29308-4" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC" displayName="Diagnosis" />
+                                    <statusCode code="active" />
+                                    <entryRelationship typeCode="SUBJ" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01" />
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2022-06-01" />
+                                            <id root="1.2.840.114350.1.13.4304.2.7.1.1099.1"
+                                                extension="XX773-399227" />
+                                            <code code="282291009"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation code="29308-4"
+                                                    codeSystem="2.16.840.1.113883.6.1"
+                                                    codeSystemName="LOINC" displayName="Diagnosis" />
+                                            </code>
+                                            <text>Cleft hard palate</text>
+                                            <statusCode code="completed" />
+                                            <effectiveTime>
+                                                <low value="19811015" />
+                                            </effectiveTime>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                code="448915004" codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD">
+                                                <originalText>Cleft hard palate</originalText>
+                                                <translation code="Q35.1"
+                                                    codeSystem="2.16.840.1.113883.6.90"
+                                                    codeSystemName="ICD10"
+                                                    displayName="Cleft hard palate" />
+                                                <translation code="749.00"
+                                                    codeSystem="2.16.840.1.113883.6.103"
+                                                    codeSystemName="ICD9"
+                                                    displayName="Cleft hard palate" />
+                                                <translation code="745491"
+                                                    codeSystem="2.16.840.1.113883.3.247.1.1"
+                                                    codeSystemName="Intelligent Medical Objects ProblemIT"
+                                                    displayName="Cleft hard palate" />
+                                            </value>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                    extension="2019-10-01" />
+                                                <time value="19811016122831-0500" />
+                                                <assignedAuthor>
+                                                    <id root="1.2.840.114350.1.13.4304.2.7.1.1133"
+                                                        extension="XX6050978" />
+                                                    <id root="2.16.840.1.113883.4.6"
+                                                        extension="XX13576542" />
+                                                </assignedAuthor>
+                                            </author>
+                                            <participant typeCode="LOC">
+                                                <participantRole classCode="SDLOC">
+                                                    <templateId
+                                                        root="2.16.840.1.113883.10.20.22.4.32" />
+                                                    <code nullFlavor="UNK">
+                                                        <translation code="0"
+                                                            codeSystem="1.2.840.114350.1.72.1.7.7.10.698084.18465"
+                                                            codeSystemName="Epic.isEDDX" />
+                                                    </code>
+                                                    <addr>
+                                                        <streetAddressLine nullFlavor="UNK" />
+                                                        <city nullFlavor="UNK" />
+                                                        <state nullFlavor="UNK" />
+                                                        <postalCode nullFlavor="UNK" />
+                                                    </addr>
+                                                    <playingEntity classCode="PLC">
+                                                        <name nullFlavor="UNK" />
+                                                    </playingEntity>
+                                                </participantRole>
+                                            </participant>
+                                            <entryRelationship typeCode="REFR">
+                                                <observation classCode="OBS" moodCode="EVN">
+                                                    <templateId
+                                                        root="2.16.840.1.113883.10.20.22.4.6" />
+                                                    <templateId
+                                                        root="2.16.840.1.113883.10.20.22.4.6"
+                                                        extension="2019-06-20" />
+                                                    <code code="33999-4"
+                                                        codeSystem="2.16.840.1.113883.6.1"
+                                                        displayName="Status" />
+                                                    <statusCode code="completed" />
+                                                    <effectiveTime>
+                                                        <low value="19811015" />
+                                                    </effectiveTime>
+                                                    <value
+                                                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                        code="55561003"
+                                                        codeSystem="2.16.840.1.113883.6.96"
+                                                        xsi:type="CD" displayName="Active" />
+                                                </observation>
+                                            </entryRelationship>
+                                            <entryRelationship typeCode="REFR">
+                                                <observation classCode="OBS" moodCode="EVN">
+                                                    <templateId
+                                                        root="2.16.840.1.113883.10.20.24.3.166"
+                                                        extension="2019-12-01" />
+                                                    <code code="263486008"
+                                                        codeSystem="2.16.840.1.113883.6.96"
+                                                        codeSystemName="SNOMED CT"
+                                                        displayName="Rank" />
+                                                    <value
+                                                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                        xsi:type="INT" value="1" />
+                                                </observation>
+                                            </entryRelationship>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.1099.1"
+                                        extension="xx887-856560-mapypdh" />
+                                    <code code="29308-4" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC" displayName="Diagnosis" />
+                                    <statusCode code="active" />
+                                    <entryRelationship typeCode="SUBJ" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01" />
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2022-06-01" />
+                                            <id root="1.2.840.114350.1.13.4304.2.7.1.1099.1"
+                                                extension="XX773-399227" />
+                                            <code code="282291009"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation code="29308-4"
+                                                    codeSystem="2.16.840.1.113883.6.1"
+                                                    codeSystemName="LOINC" displayName="Diagnosis" />
+                                            </code>
+                                            <text>Cleft hard palate</text>
+                                            <statusCode code="completed" />
+                                            <effectiveTime>
+                                                <low value="19811015" />
+                                            </effectiveTime>
+                                            <value
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                code="448915004" codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD">
+                                                <originalText>Cleft hard palate</originalText>
+                                                <translation code="Q35.1"
+                                                    codeSystem="2.16.840.1.113883.6.90"
+                                                    codeSystemName="ICD10"
+                                                    displayName="Cleft hard palate" />
+                                                <translation code="749.00"
+                                                    codeSystem="2.16.840.1.113883.6.103"
+                                                    codeSystemName="ICD9"
+                                                    displayName="Cleft hard palate" />
+                                                <translation code="745491"
+                                                    codeSystem="2.16.840.1.113883.3.247.1.1"
+                                                    codeSystemName="Intelligent Medical Objects ProblemIT"
+                                                    displayName="Cleft hard palate" />
+                                            </value>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                    extension="2019-10-01" />
+                                                <time value="19811017004309-0500" />
+                                                <assignedAuthor>
+                                                    <id root="1.2.840.114350.1.13.4304.2.7.1.1133"
+                                                        extension="XX6050978" />
+                                                    <id root="2.16.840.1.113883.4.6"
+                                                        extension="XX13576542" />
+                                                </assignedAuthor>
+                                            </author>
+                                            <entryRelationship typeCode="REFR">
+                                                <observation classCode="OBS" moodCode="EVN">
+                                                    <templateId
+                                                        root="2.16.840.1.113883.10.20.22.4.6" />
+                                                    <templateId
+                                                        root="2.16.840.1.113883.10.20.22.4.6"
+                                                        extension="2019-06-20" />
+                                                    <code code="33999-4"
+                                                        codeSystem="2.16.840.1.113883.6.1"
+                                                        displayName="Status" />
+                                                    <statusCode code="completed" />
+                                                    <effectiveTime>
+                                                        <low value="19811015" />
+                                                    </effectiveTime>
+                                                    <value
+                                                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                        code="55561003"
+                                                        codeSystem="2.16.840.1.113883.6.96"
+                                                        xsi:type="CD" displayName="Active" />
+                                                </observation>
+                                            </entryRelationship>
+                                            <entryRelationship typeCode="REFR">
+                                                <observation classCode="OBS" moodCode="EVN">
+                                                    <templateId
+                                                        root="2.16.840.1.113883.10.20.24.3.166"
+                                                        extension="2019-12-01" />
+                                                    <code code="263486008"
+                                                        codeSystem="2.16.840.1.113883.6.96"
+                                                        codeSystemName="SNOMED CT"
+                                                        displayName="Rank" />
+                                                    <value
+                                                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                        xsi:type="INT" value="1" />
+                                                </observation>
+                                            </entryRelationship>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01" />
+                                    <id root="1.2.840.114350.1.13.4304.2.7.1.1099.1"
+                                        extension="xx762-94766-pgvumaq" />
+                                    <code code="29308-4" codeSystem="2.16.840.1.113883.6.1"
+                                        codeSystemName="LOINC" displayName="Diagnosis" />
+                                    <statusCode code="active" />
+                                    <entryRelationship typeCode="SUBJ" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN"
+                                            negationInd="false">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01" />
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2022-06-01" />
+                                            <templateId root="2.16.840.1.113883.10.20.15.2.3.3"
+                                                extension="2016-12-01" />
+                                            <id root="1.2.840.114350.1.13.4304.2.7.1.1099.1"
+                                                extension="XX383-28881" />
+                                            <code code="282291009"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation code="29308-4"
+                                                    codeSystem="2.16.840.1.113883.6.1"
+                                                    codeSystemName="LOINC" displayName="Diagnosis" />
+                                            </code>
+                                            <text>Zika virus disease</text>
+                                            <statusCode code="completed" />
+                                            <effectiveTime>
+                                                <low value="19811015" />
+                                            </effectiveTime>
+                                            <value xmlns:sdtc="urn:hl7-org:sdtc"
+                                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                code="3928002" codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"
+                                                sdtc:valueSet="2.16.840.1.114222.4.11.7508"
+                                                sdtc:valueSetVersion="3/29/2022">
+                                                <originalText>Zika virus disease</originalText>
+                                                <translation code="A92.5"
+                                                    codeSystem="2.16.840.1.113883.6.90"
+                                                    codeSystemName="ICD10"
+                                                    displayName="Zika virus disease" />
+                                                <translation code="066.3"
+                                                    codeSystem="2.16.840.1.113883.6.103"
+                                                    codeSystemName="ICD9"
+                                                    displayName="Zika virus disease" />
+                                                <translation code="25447"
+                                                    codeSystem="2.16.840.1.113883.3.247.1.1"
+                                                    codeSystemName="Intelligent Medical Objects ProblemIT"
+                                                    displayName="Zika virus disease" />
+                                            </value>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                    extension="2019-10-01" />
+                                                <time value="19850728232732-0600" />
+                                                <assignedAuthor>
+                                                    <id root="1.2.840.114350.1.13.4304.2.7.1.1133"
+                                                        extension="XX6050978" />
+                                                    <id root="2.16.840.1.113883.4.6"
+                                                        extension="XX13576542" />
+                                                </assignedAuthor>
+                                            </author>
+                                            <entryRelationship typeCode="REFR">
+                                                <observation classCode="OBS" moodCode="EVN">
+                                                    <templateId
+                                                        root="2.16.840.1.113883.10.20.22.4.6" />
+                                                    <templateId
+                                                        root="2.16.840.1.113883.10.20.22.4.6"
+                                                        extension="2019-06-20" />
+                                                    <code code="33999-4"
+                                                        codeSystem="2.16.840.1.113883.6.1"
+                                                        displayName="Status" />
+                                                    <statusCode code="completed" />
+                                                    <effectiveTime>
+                                                        <low value="19811015" />
+                                                    </effectiveTime>
+                                                    <value
+                                                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                        code="55561003"
+                                                        codeSystem="2.16.840.1.113883.6.96"
+                                                        xsi:type="CD" displayName="Active" />
+                                                </observation>
+                                            </entryRelationship>
+                                            <entryRelationship typeCode="REFR">
+                                                <observation classCode="OBS" moodCode="EVN">
+                                                    <templateId
+                                                        root="2.16.840.1.113883.10.20.24.3.166"
+                                                        extension="2019-12-01" />
+                                                    <code code="263486008"
+                                                        codeSystem="2.16.840.1.113883.6.96"
+                                                        codeSystemName="SNOMED CT"
+                                                        displayName="Rank" />
+                                                    <value
+                                                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                        xsi:type="INT" value="0" />
+                                                </observation>
+                                            </entryRelationship>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                </section>
+            </component>
+        </structuredBody>
+    </component>
+    <section>
+        <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.1.2" />
+        <id root="0a4981c4-da2e-44ed-bc7e-6b8e7a823f53" />
+        <code code="88085-6" codeSystem="2.16.840.1.113883.6.1"
+            displayName="Reportability response report Document Public health" />
+        <title>Reportability Response</title>
+        <effectiveTime value="20250217182551+0000" />
+        <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" displayName="Normal" />
+        <entry>
+            <act classCode="ACT" moodCode="EVN">
+                <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.3.29" />
+                <id root="39d966b9-8a3a-4024-93d8-138e97d5898a" />
+                <code code="RRVS20" codeSystem="2.16.840.1.114222.4.5.274"
+                    codeSystemName="PHIN VS (CDC Local Coding System)"
+                    displayName="eICR was processed - with a warning" />
+                <entryRelationship typeCode="RSON">
+                    <observation classCode="OBS" moodCode="EVN">
+                        <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.3.21" />
+                        <id root="e39d6ae2-8c6e-4638-9b33-412996586f42" />
+                        <code code="RR6" codeSystem="2.16.840.1.114222.4.5.232"
+                            codeSystemName="PHIN Questions"
+                            displayName="eICR processing status reason" />
+                        <value code="RRVS29" codeSystem="2.16.840.1.114222.4.5.274"
+                            codeSystemName="PHIN VS (CDC Local Coding System)"
+                            displayName="The eICR was processed with the warning of: outdated eRSD (RCTC) version."
+                            xsi:type="CD" />
+                        <entryRelationship typeCode="RSON">
+                            <observation classCode="OBS" moodCode="EVN">
+                                <templateId extension="2017-04-01"
+                                    root="2.16.840.1.113883.10.20.15.2.3.32" />
+                                <id root="80f7b4ff-4d96-46ef-ae8f-af1f9c1f206c" />
+                                <code code="RRVS31" codeSystem="2.16.840.1.114222.4.5.274"
+                                    codeSystemName="PHIN VS (CDC Local Coding System)"
+                                    displayName="Outdated eRSD (RCTC) Version Detail" />
+                                <value xsi:type="ST">3/29/2022</value>
+                            </observation>
+                        </entryRelationship>
+                        <entryRelationship typeCode="RSON">
+                            <observation classCode="OBS" moodCode="EVN">
+                                <templateId extension="2017-04-01"
+                                    root="2.16.840.1.113883.10.20.15.2.3.32" />
+                                <id root="80f7b4ff-4d96-46ef-ae8f-af1f9c1f206c" />
+                                <code code="RRVS33" codeSystem="2.16.840.1.114222.4.5.274"
+                                    codeSystemName="PHIN VS (CDC Local Coding System)"
+                                    displayName="Expected eRSD (RCTC) Version Detail" />
+                                <value xsi:type="ST">The expected eRSD (RCTC) version
+                                    should be one of the following:
+                                    ["2024-06-28","1.2.4.0","3.x.x","2024-04-05"]
+                                </value>
+                            </observation>
+                        </entryRelationship>
+                    </observation>
+                </entryRelationship>
+                <entryRelationship typeCode="SPRT">
+                    <observation classCode="OBS" moodCode="EVN">
+                        <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.3.33" />
+                        <id root="80f7b4ff-4d96-46ef-ae8f-af1f9c1f206e" />
+                        <code code="RR10" codeSystem="2.16.840.1.114222.4.5.232"
+                            codeSystemName="PHIN Questions" displayName="eICR Validation Output" />
+                        <value mediaType="text/xml" xsi:type="ED">
+                            <Report xmlns="urn:aims-org:val">
+                            </Report>
+                        </value>
+                    </observation>
+                </entryRelationship>
+            </act>
+        </entry>
+        <entry typeCode="DRIV">
+            <organizer classCode="CLUSTER" moodCode="EVN">
+                <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.3.34" />
+                <code code="RR11" codeSystem="2.16.840.1.114222.4.5.232"
+                    codeSystemName="PHIN Questions"
+                    displayName="Reportability Response Coded Information" />
+                <statusCode code="completed" />
+                <component>
+                    <observation classCode="OBS" moodCode="EVN">
+                        <templateId extension="2017-04-01" root="2.16.840.1.113883.10.20.15.2.3.12" />
+                        <id root="e67ceee5-22ac-4ca3-a5e3-94b7ad5b81f6" />
+                        <code code="64572001" codeSystem="2.16.840.1.113883.6.96"
+                            codeSystemName="SNOMED" displayName="Condition">
+                            <translation code="75323-6" codeSystem="2.16.840.1.113883.6.1"
+                                codeSystemName="LOINC" displayName="Condition" />
+                        </code>
+                        <value nullFlavor="NA" xsi:type="CD" />
+                        <entryRelationship typeCode="COMP">
+                            <organizer classCode="CLUSTER" moodCode="EVN">
+                                <templateId extension="2017-04-01"
+                                    root="2.16.840.1.113883.10.20.15.2.3.13" />
+                                <id root="fc1883ea-28fa-4e6a-80a7-fbf9973830fb" />
+                                <code nullFlavor="NA" />
+                                <statusCode code="completed" />
+                                <participant typeCode="LOC">
+                                    <templateId extension="2017-04-01"
+                                        root="2.16.840.1.113883.10.20.15.2.4.3" />
+                                    <participantRole>
+                                        <id extension="wi" root="2.16.840.1.113883.4.6" />
+                                        <code code="RR12" codeSystem="2.16.840.1.114222.4.5.232"
+                                            codeSystemName="PHIN Questions"
+                                            displayName="Rules Authoring Agency" />
+                                        <addr use="WP">
+                                            <streetAddressLine>1 W Wilson
+                                                St</streetAddressLine>
+                                            <city>Madison</city>
+                                            <state>WI</state>
+                                            <postalCode>53703</postalCode>
+                                        </addr>
+                                        <telecom use="WP" value="DHSWEDSS@wi.gov" />
+                                        <telecom use="WP" value="DHSWEDSS@wi.gov" />
+                                        <playingEntity>
+                                            <name>Wisconsin Department of Health
+                                                Services</name>
+                                        </playingEntity>
+                                    </participantRole>
+                                </participant>
+                                <participant typeCode="LOC">
+                                    <templateId extension="2017-04-01"
+                                        root="2.16.840.1.113883.10.20.15.2.4.1" />
+                                    <participantRole>
+                                        <id extension="wi" root="2.16.840.1.113883.4.6" />
+                                        <code code="RR7" codeSystem="2.16.840.1.114222.4.5.232"
+                                            codeSystemName="PHIN Questions"
+                                            displayName="Routing Entity" />
+                                        <addr use="WP">
+                                            <streetAddressLine>1 W Wilson
+                                                St</streetAddressLine>
+                                            <city>Madison</city>
+                                            <state>WI</state>
+                                            <postalCode>53703</postalCode>
+                                        </addr>
+                                        <telecom use="WP" value="DHSWEDSS@wi.gov" />
+                                        <telecom use="WP" value="DHSWEDSS@wi.gov" />
+                                        <playingEntity>
+                                            <name>Wisconsin Department of Health
+                                                Services</name>
+                                        </playingEntity>
+                                    </participantRole>
+                                </participant>
+                                <component typeCode="COMP">
+                                    <observation classCode="OBS" moodCode="EVN">
+                                        <templateId extension="2017-04-01"
+                                            root="2.16.840.1.113883.10.20.15.2.3.19" />
+                                        <id root="25dceeef-2238-4de1-bacb-430029efd1ad" />
+                                        <code code="RR1" codeSystem="2.16.840.1.114222.4.5.232"
+                                            codeSystemName="PHIN Questions"
+                                            displayName="Determination of reportability" />
+                                        <value code="RRVS4" codeSystem="2.16.840.1.114222.4.5.274"
+                                            codeSystemName="PHIN VS (CDC Local Coding System)"
+                                            displayName="No rule met" xsi:type="CD" />
+                                    </observation>
+                                </component>
+                            </organizer>
+                        </entryRelationship>
+                    </observation>
+                </component>
+            </organizer>
+        </entry>
+    </section>
+</ClinicalDocument>

--- a/data/Templates/eCR/Header.liquid
+++ b/data/Templates/eCR/Header.liquid
@@ -76,9 +76,26 @@
 {% endfor -%}
 
 {% if msg.ClinicalDocument.section.code.code and msg.ClinicalDocument.section.code.code == "88085-6" -%}
+  {% comment %} Reportability Response {% endcomment %}
   {% assign sectionId = msg.ClinicalDocument.section | to_json_string | generate_uuid -%}
   {% assign entries = msg.ClinicalDocument.section.entry | to_array -%}
   {% for entry in entries -%}
+    {% comment %} Observation: eICR Processing Status {% endcomment %}
+    {% if entry.act.templateId.root and entry.act.templateId.root == "2.16.840.1.113883.10.20.15.2.3.29"-%}
+      {% assign processingStatusId = entry.act | to_json_string | generate_uuid -%}
+      {% include "Resource/ObservationRREICRProcessingStatus" ob: entry.act, ID: processingStatusId -%}
+
+      {% assign statusEntryRelats = entry.act.entryRelationship | to_array -%} 
+      {% for statusEntryRelat in statusEntryRelats -%}
+        {% if statusEntryRelat.observation and statusEntryRelat.observation.templateId.root == "2.16.840.1.113883.10.20.15.2.3.21" -%}
+          {% comment %} Observation: eICR Processing Status Reason {% endcomment %}
+          {% assign obsId = statusEntryRelat.observation | to_json_string | generate_uuid -%}
+          {% include "Resource/ObservationRREICRProcessingStatusReason" ob: statusEntryRelat.observation ID: obsId -%}
+        {% endif -%}
+      {% endfor -%}
+    {% endif -%}
+
+    {% comment %} Reportability Response Coded Information Organizer {% endcomment %}
     {% if entry.organizer.templateId.root and entry.organizer.templateId.root == "2.16.840.1.113883.10.20.15.2.3.34" -%}
       {% assign comps = entry.organizer.component | to_array -%}
       {% for comp in comps -%}

--- a/data/Templates/eCR/Resource/_Composition.liquid
+++ b/data/Templates/eCR/Resource/_Composition.liquid
@@ -239,44 +239,23 @@
                     },
                     {
                         "url" : "http://hl7.org/fhir/us/ecr/StructureDefinition/rr-eicr-processing-status-extension",
-                        "valueCodeableConcept": {
-                            "coding": [
-                                {
-                                    {% assign rrentries = composition.section.entry | to_array -%}
-                                    {% for rrentry in rrentries -%}
-                                        {% if rrentry.act.templateId.root == "2.16.840.1.113883.10.20.15.2.3.29" -%}
-                                            {% if rrentry.act.code.code == "RRVS20" %}
-                                                {% assign subrrentrys = rrentry.act.entryRelationship | to_array -%}
-                                                {% for subrrentry in subrrentrys %}
-                                                    {% if subrrentry.typeCode != "SPRT" %}
-                                                        "entries": [
-                                                            {
-                                                            "eRSDwarnings": [
-                                                                {
-                                                                    "id": "{{ subrrentry.observation.id.root }}",
-                                                                    {% include 'DataType/Coding' Coding: subrrentry.observation.value -%}
-                                                                },
-                                                                {% assign ers = subrrentry.observation.entryRelationship | to_array -%}
-                                                                {% for er in ers -%}
-                                                                    {
-                                                                        "id": "{{ er.observation.id.root }}",
-                                                                        "value": "{{- er.observation.value._ | escape_special_chars -}}",
-                                                                        {% include 'DataType/Coding' Coding: er.observation.code -%},
-                                                                    },
-                                                                {% endfor -%}
-                                                                ],
-                                                            },
-                                                        ],
-                                                    {% endif -%}
-                                                {% endfor %}
-                                            {% else %}
-                                                {% include 'DataType/Coding' Coding: rrentry.act.code -%}
-                                            {% endif -%}
-                                        {% endif -%}
-                                    {% endfor -%}
-                                },
-                            ],
-                        },
+                        "extension": [
+                            {% assign rrentries = composition.section.entry | to_array -%}
+                            {% for rrentry in rrentries -%}
+                                {% comment %} Extension: eICR Processing Status {% endcomment %}
+                                {% if rrentry.act.templateId.root and rrentry.act.templateId.root == "2.16.840.1.113883.10.20.15.2.3.29" -%}
+                                    {
+                                        "url":"eICRProcessingStatus",
+                                        "valueReference": {
+                                            {% assign processingStatusId = rrentry.act | to_json_string | generate_uuid -%}
+                                            {% assign fullProcessingStatusId = processingStatusId | prepend: 'Observation/' -%}
+                                            "reference":"{{ fullProcessingStatusId }}",
+                                            "display": "{{ rrentry.act.code.displayName }}"
+                                        }
+                                    }
+                                {% endif -%}
+                            {% endfor -%}
+                        ]
                     },
                 ],
                 "code": {

--- a/data/Templates/eCR/Resource/_ObservationRREICRProcessingStatus.liquid
+++ b/data/Templates/eCR/Resource/_ObservationRREICRProcessingStatus.liquid
@@ -7,7 +7,7 @@
         {
             "profile":
             [
-                "http://hl7.org/fhir/us/ecr/StructureDefinition/rr-eicr-processing-status-obervation",
+                "http://hl7.org/fhir/us/ecr/StructureDefinition/rr-eicr-processing-status-observation",
             ],
         },
 
@@ -43,6 +43,6 @@
     },
     "request":{
         "method":"PUT",
-        "url":"obervation/{{ ID }}",
+        "url":"Observation/{{ ID }}",
     },
 },

--- a/data/Templates/eCR/Resource/_ObservationRREICRProcessingStatus.liquid
+++ b/data/Templates/eCR/Resource/_ObservationRREICRProcessingStatus.liquid
@@ -1,0 +1,48 @@
+{
+    "fullUrl":"urn:uuid:{{ ID }}",
+    "resource":{
+        "resourceType": "Observation",
+        "id":"{{ ID }}",
+        "meta":
+        {
+            "profile":
+            [
+                "http://hl7.org/fhir/us/ecr/StructureDefinition/rr-eicr-processing-status-obervation",
+            ],
+        },
+
+        "identifier":
+        [
+            {% assign ids = ob.id | to_array -%}
+            {% for id in ids -%}
+            { {% include 'DataType/Identifier' Identifier: id -%} },
+            {% endfor -%}
+        ],
+        "status":"final",
+        "code":
+        {
+            "coding": 
+            [
+                { {% include 'DataType/Coding' Coding: ob.code -%} },
+            ]
+        },
+        {% assign obEntryRelats = ob.entryRelationship | to_array -%}
+        {% for obEntryRelat in obEntryRelats -%}
+            {% if obEntryRelat.observation and obEntryRelat.observation.templateId.root == "2.16.840.1.113883.10.20.15.2.3.21" -%}
+                {% comment %} Reference: eICR Processing Status Reason Observation {% endcomment %}
+                {% assign obsId = obEntryRelat.observation | to_json_string | generate_uuid -%}
+                {% assign fullObsId = obsId | prepend: 'Observation/' -%}
+                "hasMember":
+                    [
+                        {
+                            "reference": "{{ fullObsId }}"
+                        },
+                    ],
+            {% endif -%}
+        {% endfor -%}
+    },
+    "request":{
+        "method":"PUT",
+        "url":"obervation/{{ ID }}",
+    },
+},

--- a/data/Templates/eCR/Resource/_ObservationRREICRProcessingStatusReason.liquid
+++ b/data/Templates/eCR/Resource/_ObservationRREICRProcessingStatusReason.liquid
@@ -1,0 +1,53 @@
+{
+    "fullUrl":"urn:uuid:{{ ID }}",
+    "resource":{
+        "resourceType": "Observation",
+        "id":"{{ ID }}",
+        "meta":
+        {
+            "profile":
+            [
+                "http://hl7.org/fhir/us/ecr/StructureDefinition/rr-eicr-processing-status-reason-observation",
+            ],
+        },
+
+        "identifier":
+        [
+            {% assign ids = ob.id | to_array -%}
+            {% for id in ids -%}
+            { {% include 'DataType/Identifier' Identifier: id -%} },
+            {% endfor -%}
+        ],
+        "status":"final",
+        "code":
+        {
+            "coding": 
+            [
+                { {% include 'DataType/Coding' Coding: ob.code -%} },
+            ]
+        },
+        "valueCodeableConcept": {
+            {% include 'DataType/CodeableConcept' CodeableConcept: ob.value -%}
+        },
+        "component":
+        [
+            {% assign obEntryRelats = ob.entryRelationship | to_array -%}
+            {% for obEntryRelat in obEntryRelats -%}
+                {% if obEntryRelat.observation and obEntryRelat.observation.templateId.root == "2.16.840.1.113883.10.20.15.2.3.32" -%}
+                    {% comment %} eICR Processing Status Reason Details {% endcomment %}
+                    {
+                        "code":
+                        {
+                            {% include "DataType/CodeableConcept" CodeableConcept: obEntryRelat.observation.code -%}
+                        },
+                        "valueString": {{ obEntryRelat.observation.value._ | to_json_string }}
+                    },
+                {% endif -%}
+            {% endfor -%}
+        ]
+    },
+    "request":{
+        "method":"PUT",
+        "url":"obervation/{{ ID }}",
+    },
+},

--- a/data/Templates/eCR/Resource/_ObservationRREICRProcessingStatusReason.liquid
+++ b/data/Templates/eCR/Resource/_ObservationRREICRProcessingStatusReason.liquid
@@ -40,7 +40,7 @@
                         {
                             {% include "DataType/CodeableConcept" CodeableConcept: obEntryRelat.observation.code -%}
                         },
-                        "valueString": {{ obEntryRelat.observation.value._ | to_json_string }}
+                        {% include 'Utils/ValueHelper' value: obEntryRelat.observation.value -%}
                     },
                 {% endif -%}
             {% endfor -%}

--- a/data/Templates/eCR/Resource/_ObservationRREICRProcessingStatusReason.liquid
+++ b/data/Templates/eCR/Resource/_ObservationRREICRProcessingStatusReason.liquid
@@ -48,6 +48,6 @@
     },
     "request":{
         "method":"PUT",
-        "url":"obervation/{{ ID }}",
+        "url":"Observation/{{ ID }}",
     },
 },

--- a/data/Templates/eCR/Utils/_ValueHelper.liquid
+++ b/data/Templates/eCR/Utils/_ValueHelper.liquid
@@ -22,7 +22,7 @@
 {% elsif value._ %}
     "valueString":"{{ value._ | clean_string_from_tabs | escape_special_chars }}",
 {% elsif value.originalText._ %}
-    "valueString":"{{ value.originalText._ }}",
+    "valueString":"{{ value.originalText._ | clean_string_from_tabs | escape_special_chars }}",
 {% else %}
     {% assign ref = value.reference.value | default: value.originalText.reference.value -%}
     {% assign refVal = ref | replace: '#', '' -%}

--- a/data/Templates/eCR/Utils/_ValueHelper.liquid
+++ b/data/Templates/eCR/Utils/_ValueHelper.liquid
@@ -20,7 +20,7 @@
         {% endif -%}
     },
 {% elsif value._ %}
-    "valueString":"{{ value._ }}",
+    "valueString":"{{ value._ | clean_string_from_tabs | escape_special_chars }}",
 {% elsif value.originalText._ %}
     "valueString":"{{ value.originalText._ }}",
 {% else %}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/BaseConvertDataFunctionalTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/BaseConvertDataFunctionalTests.cs
@@ -219,6 +219,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests
             var data = new List<string[]>
             {
                 new[] { @"EICR", @"eCR_full.xml", @"eCR_full-expected.json" },
+                new[] { @"EICR", @"eCR_RR_combined_3_1.xml", @"eCR_RR_combined_3_1-expected.json" },
             };
             return data.Select(item => new[]
             {

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
@@ -1,0 +1,2880 @@
+{
+  "resourceType": "Bundle",
+  "type": "batch",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:1.2.840.114350.1.13.4304.2.7.8.688883.1374",
+      "resource": {
+        "resourceType": "Composition",
+        "id": "1.2.840.114350.1.13.4304.2.7.8.688883.1374",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/eicr-composition"
+          ]
+        },
+        "identifier": [
+          {
+            "use": "official",
+            "type": {
+              "coding": [
+                {
+                  "code": "55751-2",
+                  "system": "http://loinc.org",
+                  "display": "Initial Public Health Case Report"
+                }
+              ]
+            },
+            "value": "359d9b6c-da66-11ef-8f89-005056be2511",
+            "assigner": {
+              "display": "EPC"
+            }
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/composition-clinicaldocument-versionNumber",
+            "valueString": "1"
+          },
+          {
+            "url": "https://www.hl7.org/implement/standards/product_brief.cfm?product_id=436",
+            "valueString": "2022-05-01"
+          }
+        ],
+        "status": "final",
+        "type": {
+          "coding": [
+            {
+              "code": "55751-2",
+              "system": "http://loinc.org",
+              "display": "Initial Public Health Case Report"
+            }
+          ]
+        },
+        "date": "1985-07-28T22:28:26-07:00",
+        "title": "Initial Public Health Case Report",
+        "confidentiality": "N",
+        "section": [
+          {
+            "id": "4821b07e-30a6-cee3-056f-e1a78b7bd4e5",
+            "title": "Miscellaneous Notes",
+            "text": {
+              "status": "generated",
+              "div": "<list styleCode=\"xTOC\" xmlns=\"urn:hl7-org:v3\"><item><caption>REMOVED</caption><content ID=\"Note2\"><content><content styleCode=\"xLabel\">REMOVED.</content><br />REMOVED </content><br /><content styleCode=\"xLabel\">REMOVED</content><br /></content></item><item><caption>REMOVED</caption><content ID=\"Note3\"><content><content styleCode=\"xLabel\">REMOVED.</content><br />REMOVED </content><br /><content styleCode=\"xLabel\">REMOVED</content><br /></content></item></list><footnote ID=\"subTitle1\" styleCode=\"xSectionSubTitle\" xmlns=\"urn:hl7-org:v3\">documented in this encounter</footnote>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "10164-2",
+                  "system": "http://loinc.org",
+                  "display": "HISTORY OF PRESENT ILLNESS"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "366CAB00-DA66-11EF-B655-005056BE2511",
+            "title": "Immunizations",
+            "text": {
+              "status": "generated",
+              "div": "<table xmlns=\"urn:hl7-org:v3\"><colgroup><col width=\"25%\" /><col width=\"50%\" /><col width=\"25%\" /></colgroup><thead><tr><th>Immunization</th><th>Administration Dates</th><th>Next Due</th></tr></thead><tbody><tr ID=\"immunization6\"><td ID=\"immunization6Name\">REMOVED</td><td><content>REMOVED</content></td><td /></tr></tbody></table><footnote ID=\"subTitle5\" styleCode=\"xSectionSubTitle\" xmlns=\"urn:hl7-org:v3\">documented as of this encounter</footnote>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "11369-6",
+                  "system": "http://loinc.org",
+                  "display": "History of Immunization Narrative"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "368CF1FF-DA66-11EF-B655-005056BE2511",
+            "title": "Administered Medications",
+            "text": {
+              "status": "generated",
+              "div": "<table ID=\"admMedTable10\" xmlns=\"urn:hl7-org:v3\"><caption>REMOVED</caption><colgroup><col width=\"40%\" /><col width=\"10%\" span=\"6\" /></colgroup><thead><tr><th>REMOVED</th><th>REMOVED</th><th>REMOVED</th><th>Dose</th><th>REMOVED</th><th>REMOVED</th><th>REMOVED</th></tr></thead><tbody><tr styleCode=\"xRowNormal xmedRow\"><td rowspan=\"1\" styleCode=\"Rrule\"><paragraph ID=\"med7\">removed</paragraph><paragraph ID=\"sig7\" styleCode=\"xIndent\">REMOVED</paragraph><content styleCode=\"xallIndent\">REMOVED <content ID=\"indication8\">Cleft hard palate</content></content></td><td>REMOVED</td><td>REMOVED</td><td>removed</td><td /><td /><td /></tr><tr styleCode=\"xRowNormal xMergeUp\"><td styleCode=\"Rrule\" /><td colspan=\"6\" /></tr></tbody></table><footnote ID=\"subTitle9\" styleCode=\"xSectionSubTitle\" xmlns=\"urn:hl7-org:v3\">documented in this encounter</footnote>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "29549-3",
+                  "system": "http://loinc.org",
+                  "display": "MEDICATIONS ADMINISTERED"
+                }
+              ]
+            },
+            "mode": "snapshot",
+            "entry": [
+              {
+                "reference": "MedicationAdministration/dbd52596-33a3-ad0c-4085-537a69085dae"
+              }
+            ]
+          },
+          {
+            "id": "1a24abb0-5ae3-b3f2-c16e-ac7306c8749b",
+            "title": "Plan of Treatment",
+            "text": {
+              "status": "generated",
+              "div": "<table xmlns=\"urn:hl7-org:v3\"><caption>REMOVED</caption><colgroup><col width=\"10%\" /><col width=\"15%\" /><col width=\"25%\" span=\"3\" /></colgroup><thead><tr><th>Date</th><th>Type</th><th>Department</th><th>REMOVED</th><th>Description</th></tr></thead><tbody><tr ID=\"encounter12\" styleCode=\"xRowNormal\"><td>REMOVED</td><td ID=\"encounter12type\">REMOVED</td><td><paragraph>REMOVED</paragraph><paragraph>REMOVED</paragraph><paragraph>REMOVED</paragraph><paragraph>608-271-9000</paragraph></td><td><paragraph styleCode=\"Bold\">REMOVED</paragraph><paragraph>REMOVED</paragraph><paragraph>REMOVED</paragraph><paragraph>REMOVED</paragraph></td><td /></tr></tbody></table><footnote ID=\"subTitle11\" styleCode=\"xSectionSubTitle\" xmlns=\"urn:hl7-org:v3\">documented as of this encounter</footnote>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "18776-5",
+                  "system": "http://loinc.org",
+                  "display": "Plan of care note"
+                }
+              ]
+            },
+            "mode": "snapshot",
+            "entry": [
+              {
+                "reference": "CarePlan/15ad6219-c9bb-2f48-416a-816612931a67"
+              }
+            ]
+          },
+          {
+            "id": "3697709E-DA66-11EF-B655-005056BE2511",
+            "title": "Active Problems",
+            "text": {
+              "status": "generated",
+              "div": "<table xmlns=\"urn:hl7-org:v3\"><colgroup><col width=\"60%\" /><col width=\"15%\" /><col width=\"25%\" /></colgroup><thead><tr><th>Problem</th><th>Noted Date</th><th>REMOVED</th></tr></thead><tbody><tr ID=\"problem16\" styleCode=\"xRowNormal\"><td ID=\"problem16name\">Zika virus disease</td><td>REMOVED</td><td /></tr><tr ID=\"problem15\" styleCode=\"xRowAlt\"><td ID=\"problem15name\">Cleft hard palate</td><td>REMOVED</td><td /></tr></tbody></table><footnote ID=\"subTitle14\" styleCode=\"xSectionSubTitle\" xmlns=\"urn:hl7-org:v3\">removed</footnote>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "11450-4",
+                  "system": "http://loinc.org",
+                  "display": "Problem list - Reported"
+                }
+              ]
+            },
+            "mode": "snapshot",
+            "entry": [
+              {
+                "display": "Problem - Cleft hard palate",
+                "reference": "Condition/f7e19101-6043-0b0d-6661-340aa0e4b4ac"
+              },
+              {
+                "display": "Problem - Zika virus disease",
+                "reference": "Condition/5c19c722-3850-da4c-f3c4-9793e31ab05e"
+              }
+            ]
+          },
+          {
+            "id": "36989282-da66-11ef-b655-005056be2511",
+            "title": "Chief Complaint",
+            "text": {
+              "status": "generated",
+              "div": "REMOVED "
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "10154-3",
+                  "system": "http://loinc.org",
+                  "display": "CHIEF COMPLAINT"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "36A3CB85-DA66-11EF-B655-005056BE2511",
+            "title": "Results",
+            "text": {
+              "status": "generated",
+              "div": "<list styleCode=\"xTOC\" xmlns=\"urn:hl7-org:v3\"><item ID=\"Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603\"><caption ID=\"Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Procedure\"> REMOVED</caption><table><colgroup><col width=\"20%\" /><col width=\"12%\" /><col width=\"8%\" /><col width=\"20%\" /><col width=\"10%\" span=\"2\" /><col width=\"20%\" /></colgroup><thead><tr><th>Component</th><th>Value</th><th>Ref Range</th><th>Test Method</th><th>Analysis Time</th><th>Performed At</th><th>Pathologist Signature</th></tr></thead><tbody><tr ID=\"Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp1\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp1Name\"> REMOVED</td><td>12</td><td>REMOVED</td><td /><td /><td /><td ID=\"Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp1Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp2\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp2Name\"> WBC</td><td>REMOVED</td><td>REMOVED</td><td /><td /><td /><td ID=\"Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp2Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp3\" styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp3Name\"> PLT</td><td>300</td><td>REMOVED</td><td /><td /><td /><td ID=\"Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp3Signature\" /></tr><tr ID=\"Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp4\" styleCode=\"xRowAlt\"><td ID=\"Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp4Name\"> REMOVED</td><td>5</td><td>REMOVED</td><td /><td /><td /><td ID=\"Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp4Signature\" /></tr></tbody></table><table><colgroup><col width=\"20%\" span=\"5\" /></colgroup><thead><tr><th>REMOVED</th><th>REMOVED</th><th>REMOVED</th><th>REMOVED</th><th>REMOVED</th></tr></thead><tbody><tr styleCode=\"xRowNormal\"><td ID=\"Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Specimen\"> Blood</td><td>REMOVED</td><td /><td>REMOVED</td><td /></tr></tbody></table><table><thead><tr><th>Narrative</th></tr></thead><tbody><tr><td styleCode=\"xpre\"><paragraph /></td></tr></tbody></table><table><colgroup><col width=\"20%\" span=\"2\" /><col width=\"60%\" /></colgroup><thead><tr><th>Authorizing Provider</th><th>Result Type</th><th>REMOVED</th></tr></thead><tbody><tr><td>REMOVED</td><td>REMOVED</td><td>REMOVED</td></tr></tbody></table></item></list><footnote ID=\"subTitle17\" styleCode=\"xSectionSubTitle\" xmlns=\"urn:hl7-org:v3\">documented in this encounter</footnote>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "30954-2",
+                  "system": "http://loinc.org",
+                  "display": "Relevant diagnostic tests/laboratory data Narrative"
+                }
+              ]
+            },
+            "mode": "snapshot",
+            "entry": [
+              {
+                "reference": "Observation/bcdfa648-971b-836c-5a7e-5eff675f405c",
+                "display": "REMOVED"
+              },
+              {
+                "reference": "Observation/607da054-fb30-24cc-7ad4-c551f3913320",
+                "display": "REMOVED"
+              },
+              {
+                "reference": "Observation/89ef1c4f-2ad2-ad2b-ff6c-145df1e8521a",
+                "display": "REMOVED"
+              },
+              {
+                "reference": "Observation/080f8e03-814d-d5b7-82a8-4788ce8e62ed",
+                "display": "REMOVED"
+              }
+            ]
+          },
+          {
+            "id": "a37cb480-eb03-95e3-3e24-235f88d40540",
+            "title": "Social History",
+            "text": {
+              "status": "generated",
+              "div": "<table ID=\"sochist19\" xmlns=\"urn:hl7-org:v3\"><colgroup><col width=\"25%\" span=\"2\" /><col width=\"13%\" /><col width=\"12%\" /><col width=\"25%\" /></colgroup><thead><tr><th>Tobacco Use</th><th>Types</th><th>Packs/Day</th><th>Years Used</th><th>Date</th></tr></thead><tbody><tr><td>Smoking Tobacco: Never</td><td /><td ID=\"sochist19packsperday\" /><td /><td /></tr><tr ID=\"sochist19smokeless\" styleCode=\"xRowAlt\"><td>REMOVED</td><td /><td /><td /><td /></tr></tbody></table><table xmlns=\"urn:hl7-org:v3\"><colgroup><col width=\"25%\" span=\"2\" /><col width=\"50%\" /></colgroup><thead><tr><th>Alcohol Use</th><th>Standard Drinks/Week</th><th>Comments</th></tr></thead><tbody><tr><td ID=\"alcoholStatus\">Never</td><td>removed</td><td /></tr></tbody></table><table xmlns=\"urn:hl7-org:v3\"><colgroup><col width=\"50%\" /><col width=\"25%\" span=\"2\" /></colgroup><thead><tr><th>REMOVED</th><th>Value</th><th>Date Recorded</th></tr></thead><tbody><tr ID=\"BirthSex22\"><td>Sex Assigned at Birth</td><td ID=\"BirthSex22Value\">Male</td><td>REMOVED</td></tr><tr ID=\"LegalSex23\"><td>REMOVED</td><td ID=\"LegalSex23Value\">Male</td><td>REMOVED</td></tr><tr ID=\"GenderIdentity20\"><td>Gender Identity</td><td ID=\"GenderIdentity20Value\">Not on file</td><td /></tr><tr ID=\"SexualOrientation21\"><td>Sexual Orientation</td><td ID=\"SexualOrientation21Value\">Not on file</td><td /></tr></tbody></table><footnote ID=\"subTitle18\" styleCode=\"xSectionSubTitle\" xmlns=\"urn:hl7-org:v3\">documented as of this encounter</footnote>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "29762-2",
+                  "system": "http://loinc.org",
+                  "display": "Social history Narrative"
+                }
+              ]
+            },
+            "mode": "snapshot",
+            "entry": [
+              {
+                "reference": "Observation/6350e7fb-da2f-eeab-75b8-c0e6ae25968f"
+              },
+              {
+                "reference": "Observation/41173172-a928-8b21-a48d-d7d2156fe7ec"
+              },
+              {
+                "reference": "Observation/699b9556-f7cb-9164-b312-849989c064a8"
+              },
+              {
+                "reference": "Observation/e12e58c0-5b1c-ea6b-a474-26184e35bb54"
+              },
+              {
+                "reference": "Observation/83f9f9b0-3066-d990-9b77-5144f5e60333"
+              },
+              {
+                "reference": "Observation/8b1f2408-8c91-1d46-3d3f-e8699b463149"
+              }
+            ]
+          },
+          {
+            "id": "05798021-902b-710d-e4b7-82513bb2928d",
+            "title": "Last Filed Vital Signs",
+            "text": {
+              "status": "generated",
+              "div": "<table xmlns=\"urn:hl7-org:v3\"><colgroup><col width=\"25%\" span=\"4\" /></colgroup><thead><tr><th>Vital Sign</th><th>REMOVED</th><th>REMOVED</th><th>Comments</th></tr></thead><tbody><tr styleCode=\"xRowNormal\"><td styleCode=\"xcellHeader\">REMOVED</td><td><content ID=\"sysBP_5689278360\">90</content>/ <content ID=\"diaBP_5689278360\">50</content></td><td>REMOVED</td><td /></tr><tr ID=\"pulse_5689278360\" styleCode=\"xRowAlt\"><td styleCode=\"xcellHeader\">Pulse</td><td>80</td><td>REMOVED</td><td /></tr><tr ID=\"temp_5689278360\" styleCode=\"xRowNormal\"><td styleCode=\"xcellHeader\">REMOVED</td><td>REMOVED</td><td>REMOVED</td><td /></tr><tr ID=\"resp_5689278360\" styleCode=\"xRowAlt\"><td styleCode=\"xcellHeader\">REMOVED</td><td>20</td><td>REMOVED</td><td /></tr><tr ID=\"SpO2_\" styleCode=\"xRowNormal\"><td styleCode=\"xcellHeader\">REMOVED</td><td>-</td><td>-</td><td /></tr><tr ID=\"inhaled_\" styleCode=\"xRowAlt\"><td styleCode=\"xcellHeader\">REMOVED</td><td>-</td><td>-</td><td /></tr><tr ID=\"weight_5689278360\" styleCode=\"xRowNormal\"><td styleCode=\"xcellHeader\">Weight</td><td>removed</td><td>REMOVED</td><td /></tr><tr ID=\"height_5689278360\" styleCode=\"xRowAlt\"><td styleCode=\"xcellHeader\">Height</td><td>removed</td><td>REMOVED</td><td /></tr><tr ID=\"wflPerc_5689278360\" styleCode=\"xRowNormal\"><td styleCode=\"xcellHeader\">REMOVED</td><td>REMOVED</td><td>REMOVED</td><td /></tr><tr styleCode=\"xRowNormal xmergeUp\"><td colspan=\"4\"><content ID=\"wflPerc5689278360GCSource4\" styleCode=\"xIndent\"> REMOVED</content></td></tr><tr ID=\"circum_5689278360\" styleCode=\"xRowAlt\"><td styleCode=\"xcellHeader\">Head Circumference</td><td>removed</td><td>REMOVED</td><td /></tr><tr ID=\"circumPerc_5689278360\" styleCode=\"xRowNormal\"><td styleCode=\"xcellHeader\">REMOVED</td><td>REMOVED</td><td>REMOVED</td><td /></tr><tr styleCode=\"xRowNormal xmergeUp\"><td colspan=\"4\"><content ID=\"circumPerc5689278360GCSource2\" styleCode=\"xIndent\">REMOVED</content></td></tr><tr ID=\"bmi_5689278360\" styleCode=\"xRowAlt\"><td styleCode=\"xcellHeader\">REMOVED</td><td>17.17</td><td>REMOVED</td><td /></tr><tr ID=\"bmiPerc_5689278360\" styleCode=\"xRowNormal\"><td styleCode=\"xcellHeader\">REMOVED</td><td>REMOVED</td><td>REMOVED</td><td /></tr><tr styleCode=\"xRowNormal xmergeUp\"><td colspan=\"4\"><content ID=\"bmiPerc5689278360GCSource4\" styleCode=\"xIndent\"> REMOVED</content></td></tr></tbody></table><footnote ID=\"subTitle24\" styleCode=\"xSectionSubTitle\" xmlns=\"urn:hl7-org:v3\">documented in this encounter</footnote>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "8716-3",
+                  "system": "http://loinc.org",
+                  "display": "Vital signs"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "36C02380-DA66-11EF-B655-005056BE2511",
+            "title": "Procedures",
+            "text": {
+              "status": "generated",
+              "div": "<list xmlns=\"urn:hl7-org:v3\"><item><content styleCode=\"xAlert\">REMOVED.</content></item></list><br xmlns=\"urn:hl7-org:v3\" /><table xmlns=\"urn:hl7-org:v3\"><colgroup><col width=\"25%\" /><col width=\"10%\" /><col width=\"15%\" /><col width=\"25%\" span=\"2\" /></colgroup><thead><tr><th>REMOVED</th><th>REMOVED</th><th>Date/Time</th><th>REMOVED</th><th>Comments</th></tr></thead><tbody><tr ID=\"procedure27\" styleCode=\"xRowNormal\"><td><content ID=\"procedure27name\">CBC</content></td><td>Routine</td><td>REMOVED</td><td /><td><paragraph styleCode=\"Bold\">REMOVED <content styleCode=\"xLink2-Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603\"> removed</content>. </paragraph></td></tr></tbody></table><footnote ID=\"subTitle26\" styleCode=\"xSectionSubTitle\" xmlns=\"urn:hl7-org:v3\">documented in this encounter</footnote>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "47519-4",
+                  "system": "http://loinc.org",
+                  "display": "History of Procedures Document"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "36C0CA42-DA66-11EF-B655-005056BE2511",
+            "title": "Admitting Diagnoses",
+            "text": {
+              "status": "generated",
+              "div": "<content ID=\"nof31\" xmlns=\"urn:hl7-org:v3\">Not on file</content><footnote ID=\"subTitle30\" styleCode=\"xSectionSubTitle\" xmlns=\"urn:hl7-org:v3\">documented in this encounter</footnote>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "46241-6",
+                  "system": "http://loinc.org",
+                  "display": "Hospital admission diagnosis Narrative - Reported"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "cffd1a3b-142e-62cc-7d3d-621225bdf09c",
+            "title": "Reason for Visit",
+            "text": {
+              "status": "generated",
+              "div": "<list xmlns=\"urn:hl7-org:v3\"><item><table><colgroup><col width=\"25%\" /><col width=\"75%\" /></colgroup><thead><tr><th>Reason</th><th>Comments</th></tr></thead><tbody><tr ID=\"rfv33\"><td ID=\"reasonrfv33\">REMOVED</td><td /></tr></tbody></table></item></list>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "29299-5",
+                  "system": "http://loinc.org",
+                  "display": "REASON FOR VISIT"
+                }
+              ]
+            },
+            "mode": "snapshot",
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/cda/ccda/StructureDefinition/2.16.840.1.113883.10.20.22.2.12",
+                "valueString": "REMOVED"
+              }
+            ]
+          },
+          {
+            "id": "36C1EC28-DA66-11EF-B655-005056BE2511",
+            "title": "Medications",
+            "text": {
+              "status": "generated",
+              "div": "<content ID=\"nof35\" xmlns=\"urn:hl7-org:v3\">Not on file</content><footnote ID=\"subTitle34\" styleCode=\"xSectionSubTitle\" xmlns=\"urn:hl7-org:v3\">removed</footnote>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "10160-0",
+                  "system": "http://loinc.org",
+                  "display": "History of Medication use Narrative"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "c7b2bb98-1a69-858a-0c94-fcb3f7959c70",
+            "title": "Encounter Details",
+            "text": {
+              "status": "generated",
+              "div": "<table xmlns=\"urn:hl7-org:v3\"><colgroup><col width=\"10%\" /><col width=\"15%\" /><col width=\"25%\" span=\"3\" /></colgroup><thead><tr><th>Date</th><th>Type</th><th>Department</th><th>REMOVED</th><th>Description</th></tr></thead><tbody><tr ID=\"encounter36\" styleCode=\"xRowNormal\"><td>REMOVED</td><td ID=\"encounter36type\">REMOVED</td><td><paragraph>REMOVED</paragraph><paragraph>REMOVED</paragraph><paragraph>REMOVED</paragraph><paragraph>608-271-9000</paragraph></td><td><paragraph styleCode=\"Bold\">REMOVED</paragraph><paragraph>REMOVED</paragraph><paragraph>REMOVED</paragraph><paragraph>REMOVED</paragraph><paragraph>REMOVED</paragraph></td><td><content ID=\"encounter36desc\">REMOVED</content></td></tr></tbody></table>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "46240-8",
+                  "system": "http://loinc.org",
+                  "display": "History of Hospitalizations+Outpatient visits Narrative"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "146bc49a-efaa-4aae-345c-bcf32e64cb8d",
+            "title": "Reportability Response Information Section",
+            "text": {
+              "status": "generated",
+              "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Reportability Response Information Section</div>"
+            },
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/eicr-initiation-type-extension",
+                "valueCodeableConcept": {
+                  "text": "official",
+                  "coding": [
+                    {
+                      "code": "88085-6",
+                      "system": "http://loinc.org",
+                      "display": "Reportability response report Document Public health"
+                    }
+                  ]
+                }
+              },
+              {
+                "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/rr-eicr-processing-status-extension",
+                "extension": [
+                  {
+                    "url": "eICRProcessingStatus",
+                    "valueReference": {
+                      "reference": "Observation/1f41508f-a752-fb3a-9091-7473d7d3b40a",
+                      "display": "eICR was processed - with a warning"
+                    }
+                  }
+                ]
+              }
+            ],
+            "code": {
+              "coding": [
+                {
+                  "code": "88085-6",
+                  "system": "http://loinc.org",
+                  "display": "Reportability response report Document Public health"
+                }
+              ]
+            }
+          }
+        ],
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        },
+        "encounter": {
+          "reference": "Encounter/975e40cc-b7ba-f547-c5ec-69624a428444"
+        },
+        "custodian": {
+          "reference": "Organization/da341ef9-3cba-b10f-2f38-1a16afde1d65"
+        },
+        "author": [
+          {
+            "reference": "PractitionerRole/3b78b2bc-c46a-0e66-d634-f62269e7a601"
+          },
+          {
+            "reference": "Device/82ff72e2-f27f-882f-95bb-fbffa2fc2fb0"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Composition/1.2.840.114350.1.13.4304.2.7.8.688883.1374"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:975e40cc-b7ba-f547-c5ec-69624a428444",
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "975e40cc-b7ba-f547-c5ec-69624a428444",
+        "status": "unknown",
+        "class": {
+          "code": "3",
+          "system": "urn:oid:1.2.840.114350.1.72.1.30",
+          "display": "Hospital Encounter"
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.3.698084.8",
+            "value": "XX692"
+          }
+        ],
+        "period": {
+          "start": "1981-10-16T10:14:46-07:00"
+        },
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        },
+        "location": [
+          {
+            "id": "1.2.840.114350.1.13.4304.2.7.2.686980",
+            "location": {
+              "reference": "Location/b1affa82-31b4-92c5-b881-76271fecbb39",
+              "display": " Sissubo School Neighbourhood Laboratory"
+            },
+            "extension": [
+              {
+                "url": "http://build.fhir.org/ig/HL7/case-reporting/StructureDefinition-us-ph-location-definitions.html#Location.type",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "code": "1081-9",
+                      "system": "urn:oid:2.16.840.1.113883.6.259",
+                      "display": "Pediatric Medical-Surgical Ward"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "serviceProvider": {
+          "reference": "Organization/f81ca8a7-28b7-f5cd-06ca-eb2428574fdc"
+        },
+        "participant": [
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code": "ATND"
+                  }
+                ]
+              }
+            ],
+            "individual": {
+              "reference": "PractitionerRole/9d8a677a-b743-aaaa-fa02-555c6e701d8f"
+            }
+          },
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code": "ATND"
+                  }
+                ]
+              }
+            ],
+            "period": {
+              "start": "1981-10-16T10:14:46-07:00"
+            },
+            "individual": {
+              "reference": "PractitionerRole/2292332c-3705-aa46-e48d-453f81784d54"
+            }
+          },
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code": "ADM"
+                  }
+                ]
+              }
+            ],
+            "period": {
+              "start": "1981-10-16T10:14:46-07:00"
+            },
+            "individual": {
+              "reference": "PractitionerRole/2292332c-3705-aa46-e48d-453f81784d54"
+            }
+          }
+        ],
+        "diagnosis": [
+          {
+            "condition": {
+              "reference": "Condition/f7e19101-6043-0b0d-6661-340aa0e4b4ac"
+            }
+          },
+          {
+            "condition": {
+              "reference": "Condition/5c19c722-3850-da4c-f3c4-9793e31ab05e"
+            }
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Encounter/975e40cc-b7ba-f547-c5ec-69624a428444"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:b1affa82-31b4-92c5-b881-76271fecbb39",
+      "resource": {
+        "resourceType": "Location",
+        "id": "b1affa82-31b4-92c5-b881-76271fecbb39",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.2.686980",
+            "value": "XX114730"
+          }
+        ],
+        "name": " Sissubo School Neighbourhood Laboratory",
+        "address": {
+          "use": "work",
+          "line": ["4509 KAMINO OCEAN Street"],
+          "city": "Galactic City",
+          "state": "KZ",
+          "country": "AI",
+          "postalCode": "89170-2785",
+          "district": "Lah'mu"
+        },
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+3-298-900-4460-y60",
+            "use": "work"
+          }
+        ],
+        "type": [
+          {
+            "coding": [
+              {
+                "code": "1081-9",
+                "system": "urn:oid:2.16.840.1.113883.6.259",
+                "display": "Pediatric Medical-Surgical Ward"
+              }
+            ]
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Location/b1affa82-31b4-92c5-b881-76271fecbb39"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:f81ca8a7-28b7-f5cd-06ca-eb2428574fdc",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "f81ca8a7-28b7-f5cd-06ca-eb2428574fdc",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.2.696570",
+            "value": "XX7530"
+          }
+        ],
+        "name": "Institute of Takodana Neighbourhood Pharmacy & Hospital",
+        "address": [
+          {
+            "use": "work",
+            "line": ["554 KAMINO OCEAN Street"],
+            "city": "Galactic City",
+            "state": "KZ",
+            "country": "AI",
+            "postalCode": "89170-2785",
+            "district": "Lah'mu"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+3-298-900-4460-y60",
+            "use": "work"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/f81ca8a7-28b7-f5cd-06ca-eb2428574fdc"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:0336fa14-9dff-ad05-5971-64a8ac7e4827",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "0336fa14-9dff-ad05-5971-64a8ac7e4827",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/_datatype",
+            "valueString": "Responsible Party"
+          }
+        ],
+        "identifier": [
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "XX13576542"
+          }
+        ],
+        "name": [
+          {
+            "family": "Baba",
+            "given": ["Elzar"]
+          }
+        ],
+        "address": [
+          {
+            "use": "work",
+            "line": ["54018 KAMINO OCEAN Spire", "STE 820"],
+            "city": "Keren",
+            "state": "YA",
+            "postalCode": "81303"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+6-901-374-4286",
+            "use": "work"
+          }
+        ],
+        "qualification": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "208D00000X",
+                  "system": "http://nucc.org/provider-taxonomy",
+                  "display": "General Practice Physician"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Practitioner/0336fa14-9dff-ad05-5971-64a8ac7e4827"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "PractitionerRole",
+        "id": "9d8a677a-b743-aaaa-fa02-555c6e701d8f",
+        "practitioner": {
+          "reference": "Practitioner/0336fa14-9dff-ad05-5971-64a8ac7e4827"
+        },
+        "organization": {
+          "reference": "Organization/efbb6154-ef3e-32fe-91ef-0e6801e5037d"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:efbb6154-ef3e-32fe-91ef-0e6801e5037d",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "efbb6154-ef3e-32fe-91ef-0e6801e5037d",
+        "name": "Academy of Agamar Research Institute",
+        "address": [
+          {
+            "use": "work",
+            "line": [
+              "554 KAMINO OCEAN Street",
+              "Building SubaddressIdentifier"
+            ],
+            "city": "Galactic City",
+            "state": "KZ",
+            "country": "AI",
+            "postalCode": "79572",
+            "district": "Lah'mu"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/efbb6154-ef3e-32fe-91ef-0e6801e5037d"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:5a1ed5b4-e7f6-bc39-d09f-458e8904c85a",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "5a1ed5b4-e7f6-bc39-d09f-458e8904c85a",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "1234561235"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "Powers",
+            "given": ["JohnTESTPROVIDER"],
+            "suffix": [" MD"]
+          }
+        ],
+        "address": [
+          {
+            "use": "work",
+            "line": ["90001 TEST Avey", "STE 100"],
+            "city": "Washington",
+            "state": "DC",
+            "postalCode": "20000"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+1-608-271-9000",
+            "use": "work"
+          }
+        ],
+        "qualification": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "208D00000X",
+                  "system": "http://nucc.org/provider-taxonomy",
+                  "display": "General Practice Physician"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Practitioner/5a1ed5b4-e7f6-bc39-d09f-458e8904c85a"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "PractitionerRole",
+        "id": "2292332c-3705-aa46-e48d-453f81784d54",
+        "practitioner": {
+          "reference": "Practitioner/8a5c403d-7cc4-f077-bfb7-4e2f9d65efd5"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:8a5c403d-7cc4-f077-bfb7-4e2f9d65efd5",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "8a5c403d-7cc4-f077-bfb7-4e2f9d65efd5",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "1234561235"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "Powers",
+            "given": ["JohnTESTPROVIDER"],
+            "suffix": [" MD"]
+          }
+        ],
+        "address": [
+          {
+            "use": "work",
+            "line": ["90001 TEST Avey", "STE 100"],
+            "city": "Washington",
+            "state": "DC",
+            "postalCode": "20000"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+1-608-271-9000",
+            "use": "work"
+          }
+        ],
+        "qualification": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "208D00000X",
+                  "system": "http://nucc.org/provider-taxonomy",
+                  "display": "General Practice Physician"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Practitioner/8a5c403d-7cc4-f077-bfb7-4e2f9d65efd5"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:1f41508f-a752-fb3a-9091-7473d7d3b40a",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "1f41508f-a752-fb3a-9091-7473d7d3b40a",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/rr-eicr-processing-status-observation"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:39d966b9-8a3a-4024-93d8-138e97d5898a"
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "RRVS20",
+              "system": "urn:oid:2.16.840.1.114222.4.5.274",
+              "display": "eICR was processed - with a warning"
+            }
+          ]
+        },
+        "hasMember": [
+          {
+            "reference": "Observation/c53c48e6-db9a-3523-7d00-c52fbbd3f7ea"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/1f41508f-a752-fb3a-9091-7473d7d3b40a"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:c53c48e6-db9a-3523-7d00-c52fbbd3f7ea",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "c53c48e6-db9a-3523-7d00-c52fbbd3f7ea",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/rr-eicr-processing-status-reason-observation"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:e39d6ae2-8c6e-4638-9b33-412996586f42"
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "RR6",
+              "system": "urn:oid:2.16.840.1.114222.4.5.232",
+              "display": "eICR processing status reason"
+            }
+          ]
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "RRVS29",
+              "system": "urn:oid:2.16.840.1.114222.4.5.274",
+              "display": "The eICR was processed with the warning of: outdated eRSD (RCTC) version."
+            }
+          ]
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "RRVS31",
+                  "system": "urn:oid:2.16.840.1.114222.4.5.274",
+                  "display": "Outdated eRSD (RCTC) Version Detail"
+                }
+              ]
+            },
+            "valueString": "3/29/2022"
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "RRVS33",
+                  "system": "urn:oid:2.16.840.1.114222.4.5.274",
+                  "display": "Expected eRSD (RCTC) Version Detail"
+                }
+              ]
+            },
+            "valueString": "The expected eRSD (RCTC) version should be one of the following: [\"2024-06-28\",\"1.2.4.0\",\"3.x.x\",\"2024-04-05\"] "
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/c53c48e6-db9a-3523-7d00-c52fbbd3f7ea"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:da341ef9-3cba-b10f-2f38-1a16afde1d65",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "da341ef9-3cba-b10f-2f38-1a16afde1d65",
+        "identifier": [
+          {
+            "system": "urn:oid:http://hl7.org/fhir/sid/us-npi",
+            "value": "XX22521268"
+          }
+        ],
+        "name": "Academy of Agamar Research Institute",
+        "address": [
+          {
+            "use": "work",
+            "line": [
+              "554 KAMINO OCEAN Street",
+              "Building SubaddressIdentifier"
+            ],
+            "city": "Galactic City",
+            "state": "KZ",
+            "country": "AI",
+            "postalCode": "79572",
+            "district": "Lah'mu"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+3-298-900-4460-y60",
+            "use": "work"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/da341ef9-3cba-b10f-2f38-1a16afde1d65"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "PractitionerRole",
+        "id": "3b78b2bc-c46a-0e66-d634-f62269e7a601",
+        "organization": {
+          "reference": "Organization/da341ef9-3cba-b10f-2f38-1a16afde1d65"
+        },
+        "practitioner": {
+          "reference": "Practitioner/0336fa14-9dff-ad05-5971-64a8ac7e4827"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:82ff72e2-f27f-882f-95bb-fbffa2fc2fb0",
+      "resource": {
+        "resourceType": "Device",
+        "id": "82ff72e2-f27f-882f-95bb-fbffa2fc2fb0",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.1",
+            "value": "XX.6"
+          }
+        ],
+        "manufacturer": "Epic - Version 11.3",
+        "version": [
+          {
+            "value": "Epic - Version 11.3"
+          }
+        ],
+        "property": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://hl7.org/fhir/device-category",
+                  "code": "software",
+                  "display": "software"
+                }
+              ]
+            }
+          }
+        ],
+        "owner": {
+          "reference": "Organization/da341ef9-3cba-b10f-2f38-1a16afde1d65"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Device/82ff72e2-f27f-882f-95bb-fbffa2fc2fb0"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:c4d6bcaa-3af2-aef6-17b2-abc4d53104a8",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "c4d6bcaa-3af2-aef6-17b2-abc4d53104a8",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "http://hl7.org/fhir/sid/us-ssn",
+            "value": "XX5664558",
+            "assigner": {
+              "display": "Social Security Administration"
+            }
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "Erso",
+            "given": ["Fo"]
+          }
+        ],
+        "birthDate": "1860-10-14",
+        "deceasedBoolean": false,
+        "gender": "male",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+            "extension": [
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "code": "2054-5",
+                  "display": "Black or African American"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "Black or African American"
+              }
+            ]
+          },
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+            "extension": [
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "code": "2186-5",
+                  "display": "Not Hispanic or Latino"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "Not Hispanic or Latino"
+              }
+            ]
+          },
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+            "extension": [
+              {
+                "url": "value",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "code": "M",
+                      "system": "urn:oid:2.16.840.1.113883.5.1"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-genderidentity-extension",
+            "extension": [
+              {
+                "url": "value",
+                "valueString": "Not on file"
+              }
+            ]
+          }
+        ],
+        "address": [
+          {
+            "use": "home",
+            "line": ["9897 Kamino Ocean Street"],
+            "city": "Galactic City",
+            "state": "KZ",
+            "country": "AI",
+            "postalCode": "79572",
+            "district": "Lah'mu",
+            "period": {
+              "start": "1981-10-15"
+            }
+          },
+          {
+            "use": "temp",
+            "line": ["6903 KAMINO OCEAN Ave"],
+            "city": "Galactic City",
+            "state": "KZ",
+            "country": "AI",
+            "postalCode": "79572",
+            "district": "Lah'mu",
+            "period": {
+              "start": "1860-10-14",
+              "end": "1981-10-14"
+            }
+          }
+        ],
+        "maritalStatus": {
+          "coding": [
+            {
+              "code": "S",
+              "system": "urn:oid:2.16.840.1.113883.5.2",
+              "display": "Single"
+            }
+          ]
+        },
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+6-901-374-4286",
+            "use": "home"
+          },
+          {
+            "system": "email",
+            "value": "cf@example.com"
+          }
+        ],
+        "communication": [
+          {
+            "language": {
+              "coding": [
+                {
+                  "system": "urn:ietf:bcp:47",
+                  "code": "en",
+                  "display": "English"
+                }
+              ]
+            },
+            "preferred": true
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:",
+      "resource": {
+        "resourceType": "CareTeam",
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:15ad6219-c9bb-2f48-416a-816612931a67",
+      "resource": {
+        "resourceType": "CarePlan",
+        "id": "15ad6219-c9bb-2f48-416a-816612931a67",
+        "status": "unknown",
+        "intent": "proposal",
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "CarePlan/15ad6219-c9bb-2f48-416a-816612931a67"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:dbd52596-33a3-ad0c-4085-537a69085dae",
+      "resource": {
+        "resourceType": "MedicationAdministration",
+        "id": "dbd52596-33a3-ad0c-4085-537a69085dae",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.2.798268",
+            "value": "XX86340"
+          }
+        ],
+        "status": "in-progress",
+        "effectivePeriod": {
+          "start": "1981-10-16T17:31:14Z"
+        },
+        "dosage": {
+          "route": {
+            "coding": [
+              {
+                "code": "C38288",
+                "system": "urn:oid:2.16.840.1.113883.3.26.1.1",
+                "display": "Oral"
+              }
+            ]
+          },
+          "dose": {
+            "value": 10,
+            "unit": "mg/kg"
+          }
+        },
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        },
+        "medicationReference": {
+          "reference": "Medication/24e97f2a-194d-e99f-415a-ef7c7b024f09"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "MedicationAdministration/dbd52596-33a3-ad0c-4085-537a69085dae"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:24e97f2a-194d-e99f-415a-ef7c7b024f09",
+      "resource": {
+        "resourceType": "Medication",
+        "id": "24e97f2a-194d-e99f-415a-ef7c7b024f09",
+        "code": {
+          "coding": [
+            {
+              "code": "197803",
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "display": "ibuprofen 20 MG/ML Oral Suspension"
+            },
+            {
+              "code": "0363-0897-26",
+              "system": "urn:oid:2.16.840.1.113883.6.69"
+            },
+            {
+              "code": "27912",
+              "system": "urn:oid:2.16.840.1.113883.6.253"
+            },
+            {
+              "code": "66100020001820",
+              "system": "urn:oid:2.16.840.1.113883.6.68"
+            },
+            {
+              "code": "27912",
+              "system": "urn:oid:2.16.840.1.113883.6.162"
+            }
+          ]
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Medication/24e97f2a-194d-e99f-415a-ef7c7b024f09"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:f7e19101-6043-0b0d-6661-340aa0e4b4ac",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "f7e19101-6043-0b0d-6661-340aa0e4b4ac",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.2.768076",
+            "value": "XX091"
+          }
+        ],
+        "clinicalStatus": {
+          "coding": [
+            {
+              "code": "55561003",
+              "system": "http://snomed.info/sct",
+              "display": "Active"
+            }
+          ]
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "code": "problem-item-list",
+                "display": "Problem List Item",
+                "system": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "code": "448915004",
+              "system": "http://snomed.info/sct"
+            },
+            {
+              "code": "Q35.1",
+              "system": "urn:oid:2.16.840.1.113883.6.90",
+              "display": "Cleft hard palate"
+            },
+            {
+              "code": "749.00",
+              "system": "urn:oid:2.16.840.1.113883.6.103",
+              "display": "Cleft hard palate"
+            },
+            {
+              "code": "745491",
+              "system": "urn:oid:2.16.840.1.113883.3.247.1.1",
+              "display": "Cleft hard palate"
+            }
+          ]
+        },
+        "onsetDateTime": "1981-10-15",
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/f7e19101-6043-0b0d-6661-340aa0e4b4ac"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:5c19c722-3850-da4c-f3c4-9793e31ab05e",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "5c19c722-3850-da4c-f3c4-9793e31ab05e",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.2.768076",
+            "value": "XX381"
+          }
+        ],
+        "clinicalStatus": {
+          "coding": [
+            {
+              "code": "55561003",
+              "system": "http://snomed.info/sct",
+              "display": "Active"
+            }
+          ]
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "code": "problem-item-list",
+                "display": "Problem List Item",
+                "system": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "code": "3928002",
+              "system": "http://snomed.info/sct"
+            },
+            {
+              "code": "A92.5",
+              "system": "urn:oid:2.16.840.1.113883.6.90",
+              "display": "Zika virus disease"
+            },
+            {
+              "code": "066.3",
+              "system": "urn:oid:2.16.840.1.113883.6.103",
+              "display": "Zika virus disease"
+            },
+            {
+              "code": "25447",
+              "system": "urn:oid:2.16.840.1.113883.3.247.1.1",
+              "display": "Zika virus disease"
+            }
+          ]
+        },
+        "onsetDateTime": "1985-07-28",
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/5c19c722-3850-da4c-f3c4-9793e31ab05e"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:ce037697-81e6-973a-10e7-58d070f9f77b",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "ce037697-81e6-973a-10e7-58d070f9f77b",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.2.798268",
+            "value": "XX97036"
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "1698",
+              "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.2.696580",
+              "display": "CBC"
+            }
+          ]
+        },
+        "effectivePeriod": {
+          "start": "1981-10-16",
+          "end": "1981-10-16"
+        },
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        },
+        "result": [
+          {
+            "reference": "Observation/bcdfa648-971b-836c-5a7e-5eff675f405c"
+          },
+          {
+            "reference": "Observation/607da054-fb30-24cc-7ad4-c551f3913320"
+          },
+          {
+            "reference": "Observation/89ef1c4f-2ad2-ad2b-ff6c-145df1e8521a"
+          },
+          {
+            "reference": "Observation/080f8e03-814d-d5b7-82a8-4788ce8e62ed"
+          },
+          {
+            "reference": "Observation/5b1d7d64-ee1b-64e7-75a4-d7ff29fc9e77"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "DiagnosticReport/ce037697-81e6-973a-10e7-58d070f9f77b"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:bcdfa648-971b-836c-5a7e-5eff675f405c",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "bcdfa648-971b-836c-5a7e-5eff675f405c",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.6.798268.2000",
+            "value": "XX27262.4"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "30313-1",
+              "system": "http://loinc.org",
+              "display": "REMOVED"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-18T05:33:46Z",
+        "valueQuantity": {
+          "value": 12,
+          "unit": "g/dL"
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Blood"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "1981-10-16"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp1"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/bcdfa648-971b-836c-5a7e-5eff675f405c"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:607da054-fb30-24cc-7ad4-c551f3913320",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "607da054-fb30-24cc-7ad4-c551f3913320",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.6.798268.2000",
+            "value": "XX44824.7"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "33765-9",
+              "system": "http://loinc.org",
+              "display": "REMOVED"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-18T05:33:46Z",
+        "valueQuantity": {
+          "value": 10000,
+          "unit": "10*3/uL"
+        },
+        "referenceRange": [
+          {
+            "text": "REMOVED",
+            "high": {
+              "value": 500000,
+              "unit": "10*3/uL"
+            }
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Blood"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "1981-10-16"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp2"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/607da054-fb30-24cc-7ad4-c551f3913320"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:89ef1c4f-2ad2-ad2b-ff6c-145df1e8521a",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "89ef1c4f-2ad2-ad2b-ff6c-145df1e8521a",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.6.798268.2000",
+            "value": "XX20053.5"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "26515-7",
+              "system": "http://loinc.org",
+              "display": "REMOVED"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-18T05:33:46Z",
+        "valueQuantity": {
+          "value": 300,
+          "unit": "10*3/uL"
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Blood"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "1981-10-16"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp3"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/89ef1c4f-2ad2-ad2b-ff6c-145df1e8521a"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:080f8e03-814d-d5b7-82a8-4788ce8e62ed",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "080f8e03-814d-d5b7-82a8-4788ce8e62ed",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.6.798268.2000",
+            "value": "XX98970.7"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "50544-6",
+              "system": "http://loinc.org",
+              "display": "REMOVED"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-18T05:33:46Z",
+        "valueQuantity": {
+          "value": 5,
+          "unit": "ng/mL"
+        },
+        "referenceRange": [
+          {
+            "text": "2 ng/mL - 8 ng/mL",
+            "low": {
+              "value": 2,
+              "unit": "ng/mL"
+            },
+            "high": {
+              "value": 8,
+              "unit": "ng/mL"
+            }
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Blood"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "1981-10-16"
+              },
+              {
+                "url": "observation entry reference value",
+                "valueString": "#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp4"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/080f8e03-814d-d5b7-82a8-4788ce8e62ed"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:5b1d7d64-ee1b-64e7-75a4-d7ff29fc9e77",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "5b1d7d64-ee1b-64e7-75a4-d7ff29fc9e77",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.2.798268",
+            "value": "XX97036"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "effectiveDateTime": "1981-10-18T05:33:46Z",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "12",
+              "system": "urn:oid:1.2.840.114350.1.72.1.5007"
+            }
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/R4/specimen.html",
+            "extension": [
+              {
+                "url": "specimen source",
+                "valueString": "Blood"
+              },
+              {
+                "url": "specimen collection time",
+                "valueDateTime": "1981-10-16"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/5b1d7d64-ee1b-64e7-75a4-d7ff29fc9e77"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:6350e7fb-da2f-eeab-75b8-c0e6ae25968f",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "6350e7fb-da2f-eeab-75b8-c0e6ae25968f",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.1.1040.1",
+            "value": "XX075^^78581-6"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "72166-2",
+              "system": "http://loinc.org",
+              "display": "Tobacco smoking status NHIS"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-15",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "266919005",
+              "system": "http://snomed.info/sct",
+              "display": "Never smoked tobacco"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/6350e7fb-da2f-eeab-75b8-c0e6ae25968f"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:41173172-a928-8b21-a48d-d7d2156fe7ec",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "41173172-a928-8b21-a48d-d7d2156fe7ec",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.1.1040.8",
+            "value": "XX370^^645891606"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "229819007",
+              "system": "http://snomed.info/sct",
+              "display": "Tobacco use and exposure"
+            },
+            {
+              "code": "88031-0",
+              "system": "http://loinc.org",
+              "display": "Smokeless tobacco status"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-15",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "451381000124107",
+              "system": "http://snomed.info/sct",
+              "display": "Smokeless tobacco non-user"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/41173172-a928-8b21-a48d-d7d2156fe7ec"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:699b9556-f7cb-9164-b312-849989c064a8",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "699b9556-f7cb-9164-b312-849989c064a8",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.1.1040.12",
+            "value": "XX241^78523.05^009290342"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "897148007",
+              "system": "http://snomed.info/sct",
+              "display": "Alcoholic beverage intake"
+            },
+            {
+              "code": "11331-6",
+              "system": "http://loinc.org",
+              "display": "History of Alcohol Use"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-15",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "228274009",
+              "system": "http://snomed.info/sct",
+              "display": "Lifetime non-drinker (finding)"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/699b9556-f7cb-9164-b312-849989c064a8"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:e12e58c0-5b1c-ea6b-a474-26184e35bb54",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "e12e58c0-5b1c-ea6b-a474-26184e35bb54",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.1.1040.21",
+            "value": "XX81066525-12694-V8612"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "8689-2",
+              "system": "http://loinc.org",
+              "display": "History of Social function"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-15",
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/e12e58c0-5b1c-ea6b-a474-26184e35bb54"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:83f9f9b0-3066-d990-9b77-5144f5e60333",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "83f9f9b0-3066-d990-9b77-5144f5e60333",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.1.1040.23",
+            "value": "XX091^94923^77831-5"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "46098-0",
+              "system": "http://loinc.org",
+              "display": "Sex"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-16T10:09:32-07:00",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "248153007",
+              "system": "http://snomed.info/sct",
+              "display": "Male (finding)"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/83f9f9b0-3066-d990-9b77-5144f5e60333"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:8b1f2408-8c91-1d46-3d3f-e8699b463149",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "8b1f2408-8c91-1d46-3d3f-e8699b463149",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-sexual-orientation"
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "76690-7",
+              "display": "Sexual orientation"
+            }
+          ],
+          "text": "Sexual orientation"
+        },
+        "status": "final",
+        "valueString": "Not on file",
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/8b1f2408-8c91-1d46-3d3f-e8699b463149"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:06ab2e28-7e5d-3031-b644-29bd38bef2e8",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "06ab2e28-7e5d-3031-b644-29bd38bef2e8",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.1.2109.1",
+            "value": "XX83411565-lpaFA-L5523"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "8480-6",
+              "system": "http://loinc.org",
+              "display": "REMOVED"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-16T17:17:46Z",
+        "valueQuantity": {
+          "value": 90,
+          "unit": "mm[Hg]"
+        },
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/06ab2e28-7e5d-3031-b644-29bd38bef2e8"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:55b63b40-395c-6c58-dc5a-84d8fe84bfab",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "55b63b40-395c-6c58-dc5a-84d8fe84bfab",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.1.2109.1",
+            "value": "XX40890395-ozmWP-Y2671"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "8462-4",
+              "system": "http://loinc.org",
+              "display": "REMOVED"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-16T17:17:46Z",
+        "valueQuantity": {
+          "value": 50,
+          "unit": "mm[Hg]"
+        },
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/55b63b40-395c-6c58-dc5a-84d8fe84bfab"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:66c220d3-6ce9-4cfd-bb8e-1efdfc035457",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "66c220d3-6ce9-4cfd-bb8e-1efdfc035457",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.1.2109.1",
+            "value": "XX01506024-cjolx-L3283"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "8867-4",
+              "system": "http://loinc.org",
+              "display": "REMOVED"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-16T17:17:46Z",
+        "valueQuantity": {
+          "value": 80,
+          "unit": "/min"
+        },
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/66c220d3-6ce9-4cfd-bb8e-1efdfc035457"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:7855a3c3-145b-158c-97f8-c4d6325d1b9b",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "7855a3c3-145b-158c-97f8-c4d6325d1b9b",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.1.2109.1",
+            "value": "XX88375515-dgkvC86-M2951"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "8310-5",
+              "system": "http://loinc.org",
+              "display": "REMOVED"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-16T17:17:46Z",
+        "valueQuantity": {
+          "value": 36.67,
+          "unit": "Cel"
+        },
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/7855a3c3-145b-158c-97f8-c4d6325d1b9b"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:0c44d586-e6b0-2400-b615-fde6a667b249",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "0c44d586-e6b0-2400-b615-fde6a667b249",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.1.2109.1",
+            "value": "XX26130336-sotr-Q1844"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "9279-1",
+              "system": "http://loinc.org",
+              "display": "REMOVED"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-16T17:17:46Z",
+        "valueQuantity": {
+          "value": 20,
+          "unit": "/min"
+        },
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/0c44d586-e6b0-2400-b615-fde6a667b249"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:5c96eaaa-9117-bb37-58a0-64ae4dc1811c",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "5c96eaaa-9117-bb37-58a0-64ae4dc1811c",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.1.2109.1",
+            "value": "XX26228197-kzqefkL58-L8864"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "8302-2",
+              "system": "http://loinc.org",
+              "display": "REMOVED"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-16T17:17:46Z",
+        "valueQuantity": {
+          "value": 89,
+          "unit": "cm"
+        },
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/5c96eaaa-9117-bb37-58a0-64ae4dc1811c"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:b30b4fc2-107e-c8d6-a5a7-a566656c0e0f",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "b30b4fc2-107e-c8d6-a5a7-a566656c0e0f",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.1.2109.1",
+            "value": "XX91590139-vxsffhN64-V7319"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "29463-7",
+              "system": "http://loinc.org",
+              "display": "REMOVED"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-16T17:17:46Z",
+        "valueQuantity": {
+          "value": 13.6,
+          "unit": "kg"
+        },
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/b30b4fc2-107e-c8d6-a5a7-a566656c0e0f"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:826393fd-144f-86b4-5aa3-fd6a696c36cb",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "826393fd-144f-86b4-5aa3-fd6a696c36cb",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.1.2109.1",
+            "value": "XX14930537-kzn-J7801"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "39156-5",
+              "system": "http://loinc.org",
+              "display": "REMOVED"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-16T17:17:46Z",
+        "valueQuantity": {
+          "value": 17.17,
+          "unit": "kg/m2"
+        },
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/826393fd-144f-86b4-5aa3-fd6a696c36cb"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:ce6ae68e-af02-5134-0b92-5abc3a93791b",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "ce6ae68e-af02-5134-0b92-5abc3a93791b",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.1.2109.1",
+            "value": "XX70448418-ljzGvadV37-G8750"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "59576-9",
+              "system": "http://loinc.org",
+              "display": "REMOVED"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-16T17:17:46Z",
+        "valueQuantity": {
+          "value": 66.39,
+          "unit": "%"
+        },
+        "referenceRange": [
+          {
+            "text": "REMOVED"
+          }
+        ],
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/ce6ae68e-af02-5134-0b92-5abc3a93791b"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:c409dfdf-6a85-6710-cf2c-8287a88b2392",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "c409dfdf-6a85-6710-cf2c-8287a88b2392",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.1.2109.1",
+            "value": "XX31403220-bpqpcpI46-Z5266"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "8287-5",
+              "system": "http://loinc.org",
+              "display": "REMOVED"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-16T17:17:46Z",
+        "valueQuantity": {
+          "value": 50,
+          "unit": "cm"
+        },
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/c409dfdf-6a85-6710-cf2c-8287a88b2392"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:66300dc8-8fc2-9c3b-b23d-4c8d9c398a39",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "66300dc8-8fc2-9c3b-b23d-4c8d9c398a39",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.1.2109.1",
+            "value": "XX88973478-xhnrlfJismB42-F6112"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "8289-1",
+              "system": "http://loinc.org",
+              "display": "REMOVED"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-16T17:17:46Z",
+        "valueQuantity": {
+          "value": 82.86,
+          "unit": "%"
+        },
+        "referenceRange": [
+          {
+            "text": "REMOVED"
+          }
+        ],
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/66300dc8-8fc2-9c3b-b23d-4c8d9c398a39"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:6794b82a-7175-3150-38fb-9f5b295198eb",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "6794b82a-7175-3150-38fb-9f5b295198eb",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.1.2109.1",
+            "value": "XX99551761-csxTnxoD10-R3044"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "77606-2",
+              "system": "http://loinc.org",
+              "display": "REMOVED"
+            }
+          ]
+        },
+        "effectiveDateTime": "1981-10-16T17:17:46Z",
+        "valueQuantity": {
+          "value": 72.23,
+          "unit": "%"
+        },
+        "referenceRange": [
+          {
+            "text": "REMOVED"
+          }
+        ],
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/6794b82a-7175-3150-38fb-9f5b295198eb"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:e2811748-41a6-95b2-b7fb-eb3271baed16",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "e2811748-41a6-95b2-b7fb-eb3271baed16",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.1.1988.1",
+            "value": "XX28196-5493"
+          }
+        ],
+        "status": "completed",
+        "code": {
+          "coding": [
+            {
+              "code": "58410-2",
+              "system": "http://loinc.org",
+              "display": "CBC"
+            }
+          ]
+        },
+        "performedDateTime": "1981-10-16",
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Procedure/e2811748-41a6-95b2-b7fb-eb3271baed16"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:",
+      "resource": {
+        "resourceType": "Observation",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+          ]
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:c099eff8-da24-9e93-1961-f040da84ca62",
+      "resource": {
+        "resourceType": "Immunization",
+        "id": "c099eff8-da24-9e93-1961-f040da84ca62",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.2.768076",
+            "value": "XX291"
+          }
+        ],
+        "occurrenceDateTime": "1981-10-15",
+        "vaccineCode": {
+          "coding": [
+            {
+              "code": "49281-400-10",
+              "system": "urn:oid:2.16.840.1.113883.6.69"
+            }
+          ]
+        },
+        "lotNumber": "651414",
+        "manufacturer": {
+          "reference": "Organization/b5c77b86-2764-79f9-10bf-5da5e63eb7c1"
+        },
+        "status": "completed",
+        "primarySource": true,
+        "patient": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Immunization/c099eff8-da24-9e93-1961-f040da84ca62"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:b5c77b86-2764-79f9-10bf-5da5e63eb7c1",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "b5c77b86-2764-79f9-10bf-5da5e63eb7c1",
+        "name": "Sanofi Pasteur"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/b5c77b86-2764-79f9-10bf-5da5e63eb7c1"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# PULL REQUEST

## Summary
- Update FHIR conversion liquid templates to convert the following fields that provide our eRSD warnings info:
    - eICR Processing Status
    - eICR Processing Status Reason
    - eICR Processing Status Reason Details
- Add the (anonymized) 3.1 sample eCR/RR combined XML as a test file for the FHIR converter snapshot test

## Related Issue

Fixes: [#461](https://github.com/CDCgov/dibbs-ecr-viewer/issues/461)

## Acceptance Criteria

The fhir conversion should be updated to match the spec and then the corner case handling in utils/evaluate.ts should be removed.

Note from Angela: Not sure what was being called in `utils/evaluate.ts` because I don't think it exists anymore.

## Additional Information

**Previous FHIR structure**
```
Composition
    --> Extension: 
        --> eRSD Warning entries
```

**Corrected FHIR structure (according to the spec):** 
Note: Please double-check that I did this right!
```
Composition
    --> Extension: 
        --> Reference to Observation: eICR Processing Status
Observation: eICR Processing Status
    --> value: Processing Status
    --> Reference to Observation: eICR Processing Status Reason
Observation: eICR Processing Status Reason
    --> value: Processing Status Reason
    --> component: holds values for eICR Processing Status Reason Details
```

**Reference: RR spec doc:**
- RR Spec: [Link](https://www.hl7.org/implement/standards/product_brief.cfm?product_id=470)
    - Search for: eICR Processing Status, eICR Processing Status Reason, eICR Processing Status Reason Details for more info on how they relate to each other / their value sets

**Reference: FHIR spec docs & example:**
- FHIR Spec: RR eICR Processing Status Extension (Composition) [(Link)](https://hl7.org/fhir/us/ecr/StructureDefinition-rr-eicr-processing-status-extension.html)
- FHIR Spec: RR eICR Processing Status Observation [(Link)](https://hl7.org/fhir/us/ecr/StructureDefinition-rr-eicr-processing-status-observation.html)
- FHIR Spec: RR eICR Processing Status Reason Observation [(Link)](https://hl7.org/fhir/us/ecr/StructureDefinition-rr-eicr-processing-status-reason-observation.html)
- Example bundle (good for seeing FHIR structure): https://hl7.org/fhir/us/ecr/Bundle-bundle-rr-document-one-cond-one-pha.json.html

## Checklist

Run the updated FHIR converter on the following two eCR Examples:

1. Sample eCR 3.1
- Example: eICR was processed **with a warning** (has eRSD warning, reason, details)
- Note: To run this in the FHIR converter locally, you would need the combined eICR/RR XML. This can be grabbed by running `add_rr_data_to_eicr` in `dibbs-ecr-viewer/containers/fhir-converter`, or just message me.

2. `ecr_sample_input_good_with_RR` (eICR & RR already combined)
- Example: eICR was processed (**no eRSD warnings**)
- This can be found in `dibbs-ecr-viewer` in `containers/validation/tests/assets`