### PR TITLE
refactor: use effective time helper all the places

### DIFF
--- a/data/SampleData/eCR/eCR_EveEverywoman.xml
+++ b/data/SampleData/eCR/eCR_EveEverywoman.xml
@@ -737,7 +737,10 @@
                                 extension="2014-06-09" />
                             <id root="6c844c75-aa34-411c-b7bd-5e4a9f206e29" />
                             <statusCode code="completed" />
-                            <effectiveTime xsi:type="PIVL_TS" operator="A" value="202011071159-0700" />
+                            <effectiveTime value="202011071159-0700" />
+                            <effectiveTime xsi:type="PIVL_TS" institutionSpecified="true" operator="A">
+                                <period value="12" unit="h"/>
+                            </effectiveTime>
                             <routeCode code="C38288" codeSystem="2.16.840.1.113883.3.26.1.1"
                                 codeSystemName="NCI Thesaurus" displayName="ORAL" />
                             <doseQuantity value="1" unit="g" />

--- a/data/Templates/eCR/Resource/_DiagnosticReport.liquid
+++ b/data/Templates/eCR/Resource/_DiagnosticReport.liquid
@@ -35,12 +35,7 @@
                 {% include 'DataType/CodeableConcept' CodeableConcept: diagnosticReport.code -%}
             {% endif -%}
         },
-        "effectivePeriod":
-        {
-            "start":"{{ diagnosticReport.effectiveTime.low.value | format_as_date_time }}",
-            "end":"{{ diagnosticReport.effectiveTime.high.value | format_as_date_time }}",
-        },
-        "effectiveDateTime":"{{ diagnosticReport.effectiveTime.value | format_as_date_time }}",
+        {% include 'Utils/EffectiveTime' effectiveTime: diagnosticReport.effectiveTime %}
         "extension":
             [ 
             {% if obsLabResultStatus %}

--- a/data/Templates/eCR/Resource/_MedicationAdministration.liquid
+++ b/data/Templates/eCR/Resource/_MedicationAdministration.liquid
@@ -29,7 +29,7 @@
                     "unit":"{{ medicationAdministration.doseQuantity.unit }}",
                 },
             {% endif -%}
-            {% assign  effectivePeriod = effectiveTimes | where "operator", "A" | first %}
+            {% assign  effectivePeriod = effectiveTimes | where: "operator", "A" | first %}
             {% if medicationAdministration.rateQuantity.value -%}
                 "rateQuantity":
                 {
@@ -38,7 +38,7 @@
                 },
             {% elseif effectivePeriod != null %}
                 "rateQuantity": {
-                    "value": "{{ effectivePeriod.period.value }}"",
+                    "value": "{{ effectivePeriod.period.value }}",
                     "unit": "{{ effectivePeriod.period.unit }}"
                 }
             {% endif -%}

--- a/data/Templates/eCR/Resource/_MedicationAdministration.liquid
+++ b/data/Templates/eCR/Resource/_MedicationAdministration.liquid
@@ -12,12 +12,10 @@
         ],
         "status":"{{ medicationAdministration.statusCode.code | get_property: 'ValueSet/MedicationAdministrationStatus' }}",
         {% assign effectiveTimes = medicationAdministration.effectiveTime | to_array -%}
-        "effectivePeriod":
-        {
-            "start":"{{ effectiveTimes.first.low.value | format_as_date_time }}",
-            "end":"{{ effectiveTimes.first.high.value | format_as_date_time }}",
-        },
-        "effectiveDateTime": "{{ effectiveTimes.first.value | format_as_date_time}}",
+        {% for effectiveTime in effectiveTimes %}
+            {%  comment  %} only one of the times should actually return anything here {% endcomment %}
+            {% include 'Utils/EffectiveTime' effectiveTime: effectiveTime %}
+        {% endfor %}
         "dosage":
         {
             "route":
@@ -31,12 +29,18 @@
                     "unit":"{{ medicationAdministration.doseQuantity.unit }}",
                 },
             {% endif -%}
+            {% assign  effectivePeriod = effectiveTimes | where "operator", "A" | first %}
             {% if medicationAdministration.rateQuantity.value -%}
                 "rateQuantity":
                 {
                     "value":{{ medicationAdministration.rateQuantity.value }},
                     "unit":"{{ medicationAdministration.rateQuantity.unit }}",
                 },
+            {% elseif effectivePeriod != null %}
+                "rateQuantity": {
+                    "value": "{{ effectivePeriod.period.value }}"",
+                    "unit": "{{ effectivePeriod.period.unit }}"
+                }
             {% endif -%}
         },
     },

--- a/data/Templates/eCR/Resource/_MedicationStatement.liquid
+++ b/data/Templates/eCR/Resource/_MedicationStatement.liquid
@@ -11,11 +11,7 @@
             {% endfor -%}
         ],
         "status":"{{ medicationStatement.statusCode.code | downcase | get_property: 'ValueSet/MedicationStatementStatus' }}",
-        "effectivePeriod":
-        {
-            "start":"{{ medicationStatement.effectiveTime.low.value | format_as_date_time }}",
-            "end":"{{ medicationStatement.effectiveTime.high.value | format_as_date_time }}",
-        },
+        {% include 'Utils/EffectiveTime' effectiveTime: medicationStatement.effectiveTime %}
         "dosage":
         [
             {

--- a/data/Templates/eCR/Resource/_Observation.liquid
+++ b/data/Templates/eCR/Resource/_Observation.liquid
@@ -47,18 +47,7 @@
             {% assign codes = code | concat: translations %}
             {% include 'DataType/CodeableConcept' CodeableConcept: codes -%}
         },
-        "effectivePeriod":
-        {
-            {% if observationEntry.effectiveTime.low.value -%}
-            "start":"{{ observationEntry.effectiveTime.low.value | format_as_date_time }}",
-            {% endif -%}
-            {% if observationEntry.effectiveTime.high.value -%}
-            "end":"{{ observationEntry.effectiveTime.high.value | format_as_date_time }}",
-            {% endif -%}
-        },
-        {% if observationEntry.effectiveTime.low.value == null -%}
-        "effectiveDateTime":"{{ observationEntry.effectiveTime.value | format_as_date_time }}",
-        {% endif -%}
+        {% include 'Utils/EffectiveTime' effectiveTime: observationEntry.effectiveTime %}
         "bodySite":
         {
             {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.targetSiteCode -%}

--- a/data/Templates/eCR/Resource/_ObservationDisabilityStatus.liquid
+++ b/data/Templates/eCR/Resource/_ObservationDisabilityStatus.liquid
@@ -41,18 +41,7 @@
             {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.code -%}
             {% endif -%}
         },
-        "effectivePeriod":
-        {
-            {% if observationEntry.effectiveTime.low.value -%}
-            "start":"{{ observationEntry.effectiveTime.low.value | format_as_date_time }}",
-            {% endif -%}
-            {% if observationEntry.effectiveTime.high.value -%}
-            "end":"{{ observationEntry.effectiveTime.high.value | format_as_date_time }}",
-            {% endif -%}
-        },
-        {% if observationEntry.effectiveTime.low.value == null -%}
-        "effectiveDateTime":"{{ observationEntry.effectiveTime.value | format_as_date_time }}",
-        {% endif -%}
+        {% include 'Utils/EffectiveTime' effectiveTime: observationEntry.effectiveTime %}
         {% include 'Utils/ValueHelper' value: observationEntry.value, origText: text._innerText -%}
     },
     "request":{

--- a/data/Templates/eCR/Resource/_ObservationHomeEnv.liquid
+++ b/data/Templates/eCR/Resource/_ObservationHomeEnv.liquid
@@ -41,18 +41,7 @@
             {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.code -%}
             {% endif -%}
         },
-        "effectivePeriod":
-        {
-            {% if observationEntry.effectiveTime.low.value -%}
-            "start":"{{ observationEntry.effectiveTime.low.value | format_as_date_time }}",
-            {% endif -%}
-            {% if observationEntry.effectiveTime.high.value -%}
-            "end":"{{ observationEntry.effectiveTime.high.value | format_as_date_time }}",
-            {% endif -%}
-        },
-        {% if observationEntry.effectiveTime.low.value == null -%}
-        "effectiveDateTime":"{{ observationEntry.effectiveTime.value | format_as_date_time }}",
-        {% endif -%}
+        {% include 'Utils/EffectiveTime' effectiveTime: observationEntry.effectiveTime %}
         {% include 'Utils/ValueHelper' value: observationEntry.value, origText: text._innerText %}
     },
     "request":{

--- a/data/Templates/eCR/Resource/_ObservationPastPresentOccupation.liquid
+++ b/data/Templates/eCR/Resource/_ObservationPastPresentOccupation.liquid
@@ -46,18 +46,7 @@
             {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.code -%}
             {% endif -%}
         },
-        "effectivePeriod":
-        {
-            {% if observationEntry.effectiveTime.low.value -%}
-            "start":"{{ observationEntry.effectiveTime.low.value | format_as_date_time }}",
-            {% endif -%}
-            {% if observationEntry.effectiveTime.high.value -%}
-            "end":"{{ observationEntry.effectiveTime.high.value | format_as_date_time }}",
-            {% endif -%}
-        },
-        {% if observationEntry.effectiveTime.low.value == null -%}
-        "effectiveDateTime":"{{ observationEntry.effectiveTime.value | format_as_date_time }}",
-        {% endif -%}
+        {% include 'Utils/EffectiveTime' effectiveTime: observationEntry.effectiveTime %}
         {% include 'Utils/ValueHelper' value: observationEntry.value, origText: text._innerText -%}
         "component" : [
             {% assign obsRelationships = observationEntry.entryRelationship | to_array -%}

--- a/data/Templates/eCR/Resource/_ObservationPregnancyStatus.liquid
+++ b/data/Templates/eCR/Resource/_ObservationPregnancyStatus.liquid
@@ -46,18 +46,7 @@
             {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.code -%}
             {% endif -%}
         },
-        "effectivePeriod":
-        {
-            {% if observationEntry.effectiveTime.low.value -%}
-            "start":"{{ observationEntry.effectiveTime.low.value | format_as_date_time }}",
-            {% endif -%}
-            {% if observationEntry.effectiveTime.high.value -%}
-            "end":"{{ observationEntry.effectiveTime.high.value | format_as_date_time }}",
-            {% endif -%}
-        },
-        {% if observationEntry.effectiveTime.low.value == null -%}
-        "effectiveDateTime":"{{ observationEntry.effectiveTime.value | format_as_date_time }}",
-        {% endif -%}
+        {% include 'Utils/EffectiveTime' effectiveTime: observationEntry.effectiveTime %}
         {% include 'Utils/ValueHelper' value: observationEntry.value, origText: text._innerText -%}
         "component" : [
             {% assign obsRelationships = observationEntry.entryRelationship | to_array -%}

--- a/data/Templates/eCR/Resource/_ObservationRRCondition.liquid
+++ b/data/Templates/eCR/Resource/_ObservationRRCondition.liquid
@@ -48,24 +48,7 @@
             },
           ],
         },
-        "effectivePeriod":
-        {
-            {% if observationEntry.effectiveTime.low.value -%}
-            "start":"{{ observationEntry.effectiveTime.low.value | format_as_date_time }}",
-            {% elsif observationEntry.entryRelationship.organizer.effectiveTime.low.value %}
-            "start":"{{ observationEntry.entryRelationship.organizer.effectiveTime.low.value | format_as_date_time }}",
-            {% endif -%}
-            {% if observationEntry.effectiveTime.high.value -%}
-              "end":"{{ observationEntry.effectiveTime.high.value | format_as_date_time }}",
-            {% elsif observationEntry.entryRelationship.organizer.effectiveTime.high.value -%}
-                "end":"{{ observationEntry.entryRelationship.organizer.effectiveTime.hight.value | format_as_date_time }}",
-            {% endif -%}
-        },
-        {% if observationEntry.effectiveTime.low.value == null -%}
-        "effectiveDateTime":"{{ observationEntry.effectiveTime.value | format_as_date_time }}",
-        {% elsif observationEntry.entryRelationship.organizer.effectiveTime.low.value %}
-        "effectiveDateTime":"{{ observationEntry.entryRelationship.organizer.effectiveTime.low.value | format_as_date_time }}",
-        {% endif -%}
+        {% include 'Utils/EffectiveTime' effectiveTime: observationEntry.effectiveTime | default: observationEntry.entryRelationship.organizer.effectiveTime %}
         "bodySite":
         {
             {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.targetSiteCode -%}

--- a/data/Templates/eCR/Resource/_ObservationSexualOrientation.liquid
+++ b/data/Templates/eCR/Resource/_ObservationSexualOrientation.liquid
@@ -27,18 +27,7 @@
             {% else -%}
                 "{{ observationEntry.statusCode.code | get_property: 'ValueSet/ObservationStatus' }}",
             {% endif -%},
-        "effectivePeriod":
-        {
-            {% if observationEntry.effectiveTime.low.value -%}
-            "start":"{{ observationEntry.effectiveTime.low.value | format_as_date_time }}",
-            {% endif -%}
-            {% if observationEntry.effectiveTime.high.value -%}
-            "end":"{{ observationEntry.effectiveTime.high.value | format_as_date_time }}",
-            {% endif -%}
-        },
-        {% if observationEntry.effectiveTime.low.value == null -%}
-        "effectiveDateTime":"{{ observationEntry.effectiveTime.value | format_as_date_time }}",
-        {% endif -%}
+        {% include 'Utils/EffectiveTime' effectiveTime: observationEntry.effectiveTime %}
         {% comment %} When we have eCRs with actual data for this element, revist these values {% endcomment %}
         {% comment %} May need to use this ValueSet: http://hl7.org/fhir/us/core/STU6.1/ValueSet-us-core-sexual-orientation.html {% endcomment %}
         {% include 'Utils/ValueHelper' value: observationEntry.value, origText: text._innerText -%}

--- a/data/Templates/eCR/Resource/_ObservationTravelHistory.liquid
+++ b/data/Templates/eCR/Resource/_ObservationTravelHistory.liquid
@@ -45,18 +45,7 @@
                 },
             }
         ],
-        "effectivePeriod":
-        {
-            {% if observationEntry.effectiveTime.low.value -%}
-            "start":"{{ observationEntry.effectiveTime.low.value | format_as_date_time }}",
-            {% endif -%}
-            {% if observationEntry.effectiveTime.high.value -%}
-            "end":"{{ observationEntry.effectiveTime.high.value | format_as_date_time }}",
-            {% endif -%}
-        },
-        {% if observationEntry.effectiveTime.low.value == null -%}
-        "effectiveDateTime":"{{ observationEntry.effectiveTime.value | format_as_date_time }}",
-        {% endif -%}
+        {% include 'Utils/EffectiveTime' effectiveTime: observationEntry.effectiveTime %}
         {% include 'Utils/ValueHelper' value: observationEntry.value, origText: text._innerText -%}
     },
     "request":{

--- a/data/Templates/eCR/Resource/_ObservationUsualWork.liquid
+++ b/data/Templates/eCR/Resource/_ObservationUsualWork.liquid
@@ -46,18 +46,7 @@
             {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.code -%}
             {% endif -%}
         },
-        "effectivePeriod":
-        {
-            {% if observationEntry.effectiveTime.low.value -%}
-            "start":"{{ observationEntry.effectiveTime.low.value | format_as_date_time }}",
-            {% endif -%}
-            {% if observationEntry.effectiveTime.high.value -%}
-            "end":"{{ observationEntry.effectiveTime.high.value | format_as_date_time }}",
-            {% endif -%}
-        },
-        {% if observationEntry.effectiveTime.low.value == null -%}
-        "effectiveDateTime":"{{ observationEntry.effectiveTime.value | format_as_date_time }}",
-        {% endif -%}
+        {% include 'Utils/EffectiveTime' effectiveTime: observationEntry.effectiveTime %}
         {% include 'Utils/ValueHelper' value: observationEntry.value, origText: text._innerText -%}
         "component" : [
             {% assign obsRelationships = observationEntry.entryRelationship | to_array -%}

--- a/data/Templates/eCR/Utils/_EffectiveTime.liquid
+++ b/data/Templates/eCR/Utils/_EffectiveTime.liquid
@@ -1,5 +1,5 @@
 {% if effectiveTime.low.value or effectiveTime.high.value -%}
     "{{ timeType | default: "effective" }}Period": { {% include 'DataType/Period' Period: effectiveTime %} },
-{% elsif effectiveTime.value -%}
+{%- elseif effectiveTime.value -%}
     "{{ timeType | default: "effective" }}DateTime":"{{ effectiveTime.value | format_as_date_time }}",
-{% endif -%}
+{%- endif -%}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_EveEverywoman-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_EveEverywoman-expected.json
@@ -111,7 +111,7 @@
             "mode": "snapshot"
           },
           {
-            "id": "7422c3c3-d2e5-698e-5bcf-bb90408af81e",
+            "id": "9cb0442a-fcc4-cb62-ca2f-5563110a7f1e",
             "title": "Medications Administered",
             "text": {
               "status": "generated",
@@ -129,7 +129,7 @@
             "mode": "snapshot",
             "entry": [
               {
-                "reference": "MedicationAdministration/85d010e8-1781-4c15-baa2-af86c2a0c578"
+                "reference": "MedicationAdministration/10b5eb67-b60e-0272-b5af-026b77fa9253"
               }
             ]
           },
@@ -1279,10 +1279,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:85d010e8-1781-4c15-baa2-af86c2a0c578",
+      "fullUrl": "urn:uuid:10b5eb67-b60e-0272-b5af-026b77fa9253",
       "resource": {
         "resourceType": "MedicationAdministration",
-        "id": "85d010e8-1781-4c15-baa2-af86c2a0c578",
+        "id": "10b5eb67-b60e-0272-b5af-026b77fa9253",
         "identifier": [
           {
             "system": "urn:ietf:rfc:3986",
@@ -1304,6 +1304,10 @@
           "dose": {
             "value": 1,
             "unit": "g"
+          },
+          "rateQuantity": {
+            "value": "12",
+            "unit": "h"
           }
         },
         "subject": {
@@ -1315,7 +1319,7 @@
       },
       "request": {
         "method": "PUT",
-        "url": "MedicationAdministration/85d010e8-1781-4c15-baa2-af86c2a0c578"
+        "url": "MedicationAdministration/10b5eb67-b60e-0272-b5af-026b77fa9253"
       }
     },
     {
@@ -3594,6 +3598,10 @@
           },
           "dose": {
             "value": 1
+          },
+          "rateQuantity": {
+            "value": "12",
+            "unit": "h"
           }
         },
         "subject": {

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
@@ -1303,6 +1303,10 @@
           "dose": {
             "value": 10,
             "unit": "mg/kg"
+          },
+          "rateQuantity": {
+            "value": "6",
+            "unit": "h"
           }
         },
         "subject": {

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
@@ -777,6 +777,10 @@
           "dose": {
             "value": 100,
             "unit": "mg"
+          },
+          "rateQuantity": {
+            "value": "1",
+            "unit": "d"
           }
         },
         "subject": {


### PR DESCRIPTION
Audit all usages of datetime/period types to see if they can use the `EffectiveTime` util instead of inline logic. They all could and were otherwise already accounting for both time types (except for `MedicationStatement`, which only had period, but isn't used in the viewer and may be dead code, but my confidence in that is not high enough to actually delete it).

`MedicationAdministration` had some more nuance as it has multiple meanings to its `effectiveTime` elements where one is the administration time/period and one is actually the rate at which it is administered. The logic has been updated to reflect this.

Corresponding viewer PR: https://github.com/CDCgov/dibbs-ecr-viewer/pull/949