### PR TITLE
feat: Therapeutic medicine response observation

### DIFF
--- a/data/Templates/eCR/Resource/_MedicationAdministration.liquid
+++ b/data/Templates/eCR/Resource/_MedicationAdministration.liquid
@@ -33,12 +33,12 @@
             {% if medicationAdministration.rateQuantity.value -%}
                 "rateQuantity":
                 {
-                    "value":{{ medicationAdministration.rateQuantity.value }},
+                    "value":{{ medicationAdministration.rateQuantity.value | format_quantity }},
                     "unit":"{{ medicationAdministration.rateQuantity.unit }}",
                 },
             {% elseif effectivePeriod != null %}
                 "rateQuantity": {
-                    "value": "{{ effectivePeriod.period.value }}",
+                    "value": {{ effectivePeriod.period.value | format_quantity }},
                     "unit": "{{ effectivePeriod.period.unit }}"
                 }
             {% endif -%}

--- a/data/Templates/eCR/Resource/_MedicationAdministration.liquid
+++ b/data/Templates/eCR/Resource/_MedicationAdministration.liquid
@@ -43,6 +43,19 @@
                 }
             {% endif -%}
         },
+        "extension": [
+            {% assign entryRelationships = medicationAdministration.entryRelationship | to_array %}
+            {% for entryRelationship in entryRelationships %}
+                {% if entryRelationship.observation and entryRelationship.observation.templateId.root == '2.16.840.1.113883.10.20.15.2.3.37' -%}
+                    {
+                        "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-therapeutic-medication-response-extension",
+                        "valueCodeableConcept": {
+                            {% include 'DataType/CodeableConcept' CodeableConcept: entryRelationship.observation.value -%}
+                        },
+                    }
+                {% endif %}
+            {% endfor %}
+        ]
     },
     "request":{
         "method":"PUT",

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_EveEverywoman-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_EveEverywoman-expected.json
@@ -1306,10 +1306,27 @@
             "unit": "g"
           },
           "rateQuantity": {
-            "value": "12",
+            "value": 12,
             "unit": "h"
           }
         },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-therapeutic-medication-response-extension",
+
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "code": "268910001",
+
+                  "system": "http://snomed.info/sct",
+
+                  "display": "Patient's condition improved (finding)"
+                }
+              ]
+            }
+          }
+        ],
         "subject": {
           "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
         },
@@ -3600,7 +3617,7 @@
             "value": 1
           },
           "rateQuantity": {
-            "value": "12",
+            "value": 12,
             "unit": "h"
           }
         },

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
@@ -1305,7 +1305,7 @@
             "unit": "mg/kg"
           },
           "rateQuantity": {
-            "value": "6",
+            "value": 6,
             "unit": "h"
           }
         },

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
@@ -779,7 +779,7 @@
             "unit": "mg"
           },
           "rateQuantity": {
-            "value": "1",
+            "value": 1,
             "unit": "d"
           }
         },

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Resource/MedicationAdministrationTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Resource/MedicationAdministrationTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DotLiquid;
+using Hl7.Fhir.Model;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests
+{
+    public class MedicationAdministrationTests : BaseECRLiquidTests
+    {
+        private static readonly string ECRPath = Path.Join(
+            TestConstants.ECRTemplateDirectory,
+            "Resource",
+            "_MedicationAdministration.liquid"
+        );
+
+        [Fact]
+        public void MedicationAdministration_AllFields()
+        {
+            var attributes = new Dictionary<string, object>
+            {
+                { "ID", "1234" },
+                {
+                    "medicationAdministration",
+                    Hash.FromAnonymousObject(
+                        new
+                        {
+                            templateId = new { root = "2.16.840.1.113883.10.20.22.4.16", extension = "2014-06-09" },
+                            id = new { root = "6c844c75-aa34-411c-b7bd-5e4a9f206e29", },
+                            statusCode = new { code = "completed" },
+                            effectiveTime = new object[] {
+                                new {
+                                    value = "202011071159-0700"
+                                },
+                                new {
+                                    operator_ = "A",
+                                    period = new {
+                                        value = "12",
+                                        unit = "h"
+                                    }
+                                }
+                            },
+                            routeCode = new {
+                                code = "C38288",
+                                codeSystem = "2.16.840.1.113883.3.26.1.1",
+                                codeSystemName = "NCI Thesaurus",
+                                displayName = "ORAL"
+                            },
+                            doseQuantity = new {
+                                value = "1",
+                                unit = "g"
+                            },
+                            entryRelationship = new object[] {
+                                new {
+                                    typeCode = "CAUS",
+                                    observation = new {
+                                        classCode = "OBS",
+                                        moodCode = "EVN",
+                                        templateId = new {
+                                            root = "2.16.840.1.113883.10.20.15.2.3.37",
+                                            extension = "2019-04-01"
+                                        },
+                                        id = new { root = "ab1791b0-5c71-11db-b0de-0800200c9a55" },
+                                        code = new {
+                                            code = "67540-5",
+                                            codeSystem = "2.16.840.1.113883.6.1",
+                                            codeSystemName = "LOINC",
+                                            displayName = "Response to medication"
+                                        },
+                                        statusCode = new { code = "completed" },
+                                        effectiveTime = new { low = new { value = "20201101" } },
+                                        value = new {
+                                            code = "268910001",
+                                            codeSystem = "2.16.840.1.113883.6.96",
+                                            codeSystemName = "SNOMED CT",
+                                            displayName = "Patient's condition improved (finding)",
+                                        }
+                                    }
+                                },
+                                new {
+                                    typeCode = "COMP",
+                                    observation = new { 
+                                        templateId = new { root = "2.16.840.1.113883.10.20.22.4.999" },
+                                        value = new { code = "Red herring"}
+                                    },
+                                },
+                            },
+                        }
+                    )
+                },
+            };
+            var actualFhir = GetFhirObjectFromTemplate<MedicationAdministration>(ECRPath, attributes);
+            Console.WriteLine("FOOBAR");
+
+            Assert.Equal("MedicationAdministration", actualFhir.TypeName);
+            Assert.NotNull(actualFhir.Id);
+            // Assert.Equal(
+            //     "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure",
+            //     actualFhir.Meta.Profile.First()
+            // );
+            // Assert.NotEmpty(actualFhir.Identifier);
+            // Assert.Equal(EventStatus.NotDone, actualFhir.Status);
+            // Assert.NotNull(actualFhir.Code);
+            // Assert.NotNull(actualFhir.Performed);
+            // Assert.NotEmpty(actualFhir.BodySite);
+            // Assert.Equal("Why not", actualFhir.ReasonCode.First().Coding.First().Code);
+            // Assert.Equal("Couldn't hurt", actualFhir.ReasonCode.Last().Coding.First().Code);
+            // Assert.Equal(
+            //     "METHOD", 
+            //     actualFhir.GetExtensionValue<CodeableConcept>("http://hl7.org/fhir/StructureDefinition/procedure-method").Coding.First().Code
+            // );
+            // Assert.Equal(
+            //     "CR", 
+            //     actualFhir.GetExtensionValue<CodeableConcept>("priorityCode").Coding.First().Code
+            // );
+            // var specimen = actualFhir.GetExtensions("specimen");
+            // Assert.Equal("Tissue", ((CodeableConcept)specimen.First().Value).Coding.First().Code);
+            // Assert.Equal("Bile", ((CodeableConcept)specimen.Last().Value).Coding.First().Code);
+        }
+    }
+}


### PR DESCRIPTION
# PULL REQUEST

_PR title: Remember to name your PR descriptively and follow [conventional commits](https://cheatsheets.zip/conventional-commits)!_

## Summary

- Add Therapeutic medicine response observation extension to the `MedicationActivity` resource
- Update the rateQuantity value format (from string to quantity)
- Add `MedicationAdministration` unit test
- Update snapshot tests

eCR Viewer related PR: https://github.com/CDCgov/dibbs-ecr-viewer/pull/969

## Related Issue

Fixes https://github.com/CDCgov/dibbs-ecr-viewer/issues/610

## Acceptance Criteria

- [ ] Field should be converted to FHIR
- [ ] Field should be added to the eCR Viewer
- [ ] Any relevant unit/snapshot tests should be added.

## Additional Information

Sample eCR: Eve Everywoman

Reference links:
- http://hl7.org/fhir/us/ecr/2.1.2/StructureDefinition-us-ph-therapeutic-medication-response-extension.html
- https://hl7.org/fhir/us/ecr/2.1.2/MedicationAdministration-medicationadministration-eve-everywoman-naloxone-response.json.html
- https://hl7.org/fhir/R4/medicationadministration.html