### PR TITLE
fix: conditions on rendering effective period as rate

### DIFF
--- a/data/SampleData/eCR/eCR_EveEverywoman.xml
+++ b/data/SampleData/eCR/eCR_EveEverywoman.xml
@@ -1647,6 +1647,7 @@
                                     <effectiveTime xsi:type="IVL_TS">
                                         <low value="20120318" />
                                     </effectiveTime>
+                                    <effectiveTime xsi:type="PIVL_TS" operator="A" value="202011071159-0700" />
                                     <effectiveTime xsi:type="PIVL_TS" institutionSpecified="true"
                                         operator="A">
                                         <period value="12" unit="h" />

--- a/data/Templates/eCR/Resource/_MedicationAdministration.liquid
+++ b/data/Templates/eCR/Resource/_MedicationAdministration.liquid
@@ -13,8 +13,10 @@
         "status":"{{ medicationAdministration.statusCode.code | get_property: 'ValueSet/MedicationAdministrationStatus' }}",
         {% assign effectiveTimes = medicationAdministration.effectiveTime | to_array -%}
         {% for effectiveTime in effectiveTimes %}
-            {%  comment  %} only one of the times should actually return anything here {% endcomment %}
-            {% include 'Utils/EffectiveTime' effectiveTime: effectiveTime %}
+            {% if effectiveTime.operator != "A" %}
+                {%  comment  %} only one of the times should actually return anything here {% endcomment %}
+                {% include 'Utils/EffectiveTime' effectiveTime: effectiveTime %}
+            {% endif %}
         {% endfor %}
         "dosage":
         {
@@ -29,14 +31,14 @@
                     "unit":"{{ medicationAdministration.doseQuantity.unit }}",
                 },
             {% endif -%}
-            {% assign  effectivePeriod = effectiveTimes | where: "operator", "A" | first %}
+            {% assign  effectivePeriod = effectiveTimes | where: "operator", "A" | where: "period" | first %}
             {% if medicationAdministration.rateQuantity.value -%}
                 "rateQuantity":
                 {
                     "value":{{ medicationAdministration.rateQuantity.value | format_quantity }},
                     "unit":"{{ medicationAdministration.rateQuantity.unit }}",
                 },
-            {% elseif effectivePeriod != null %}
+            {% elseif effectivePeriod.period.value %}
                 "rateQuantity": {
                     "value": {{ effectivePeriod.period.value | format_quantity }},
                     "unit": "{{ effectivePeriod.period.unit }}"

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_EveEverywoman-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_EveEverywoman-expected.json
@@ -248,7 +248,7 @@
             ]
           },
           {
-            "id": "704bf516-3860-cfb3-fd1b-26547e8ddb69",
+            "id": "efaeb74f-db14-fb34-66e4-5fde84682c12",
             "title": "Procedures",
             "text": {
               "status": "generated",
@@ -266,7 +266,7 @@
             "mode": "snapshot",
             "entry": [
               {
-                "reference": "Procedure/c8b0b1c1-4bed-4c35-522d-867e5d7e22a1"
+                "reference": "Procedure/d409ccf8-ab6a-5edf-f64e-ad74e31b74ba"
               },
               {
                 "reference": "Observation/44e6df0f-4e41-63ee-2bda-625369930b7c"
@@ -3543,10 +3543,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:c8b0b1c1-4bed-4c35-522d-867e5d7e22a1",
+      "fullUrl": "urn:uuid:d409ccf8-ab6a-5edf-f64e-ad74e31b74ba",
       "resource": {
         "resourceType": "Procedure",
-        "id": "c8b0b1c1-4bed-4c35-522d-867e5d7e22a1",
+        "id": "d409ccf8-ab6a-5edf-f64e-ad74e31b74ba",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
@@ -3600,7 +3600,7 @@
           {
             "url": "medicationAdministration",
             "valueReference": {
-              "reference": "MedicationAdministration/1b8ee8b8-7e66-4cc6-7677-a8dfa341b39d"
+              "reference": "MedicationAdministration/04117137-af0d-8f70-177c-01b862866ed2"
             }
           }
         ],
@@ -3618,7 +3618,7 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Procedure/c8b0b1c1-4bed-4c35-522d-867e5d7e22a1"
+        "url": "Procedure/d409ccf8-ab6a-5edf-f64e-ad74e31b74ba"
       }
     },
     {
@@ -3690,10 +3690,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:1b8ee8b8-7e66-4cc6-7677-a8dfa341b39d",
+      "fullUrl": "urn:uuid:04117137-af0d-8f70-177c-01b862866ed2",
       "resource": {
         "resourceType": "MedicationAdministration",
-        "id": "1b8ee8b8-7e66-4cc6-7677-a8dfa341b39d",
+        "id": "04117137-af0d-8f70-177c-01b862866ed2",
         "identifier": [
           {
             "system": "urn:ietf:rfc:3986",
@@ -3731,7 +3731,7 @@
       },
       "request": {
         "method": "PUT",
-        "url": "MedicationAdministration/1b8ee8b8-7e66-4cc6-7677-a8dfa341b39d"
+        "url": "MedicationAdministration/04117137-af0d-8f70-177c-01b862866ed2"
       }
     },
     {


### PR DESCRIPTION
In some sample data we had a non-period `operator="A"` `effectiveTime`, which was causing the converter to 🤮 . This tightens up the usage of those effective times