### PR TITLE
feat: convert lab specimen as specimen

### DIFF
--- a/data/Templates/eCR/Entry/Result/_entry.liquid
+++ b/data/Templates/eCR/Entry/Result/_entry.liquid
@@ -17,11 +17,27 @@
         {% endif -%}
     {% endif -%}
 
+    {% comment %} From 2.16.840.1.113883.10.20.15.2.3.35:2022-05-01 {% endcomment %}
     {% assign procComponents  = entry.organizer.component | to_array | where: "procedure"  %}
     {% for component in procComponents %}
         {% assign specimenId = component.procedure | to_json_string | generate_uuid -%}
         {% assign fullSpecimenId = specimenId | prepend: 'Specimen/' -%}
-        {% include 'Resource/Specimen' ID: specimenId, specimenProc: component.procedure %}
+        {% include 'Resource/SpecimenProcedure' ID: specimenId, specimenProc: component.procedure %}
+        {% include 'Reference/Specimen/Subject' ID: specimenId, REF: fullPatientId -%}
+        {% include 'Reference/DiagnosticReport/Specimen' ID: diagnosticID, REF: fullSpecimenId %}
+    {% endfor %}
+
+    {% comment %} From 2.16.840.1.113883.10.20.22.4.1:2023-05-01 {% endcomment %}
+    {% assign specs = entry.organizer.specimen | to_array  %}
+    {% for spec in specs %}
+        {% assign specimenId = spec | to_json_string | generate_uuid -%}
+        {% comment %} This specimen might have already been assigned an id via the specimen procedure, if it has, use it instead so they merge together {% endcomment %}
+        {% assign matchingSpecProcComp = procComponents | nested_where: "procedure.participant.participantRole.id.extension", spec.specimenRole.id.extension | first %}
+        {% if matchingSpecProcComp %}
+            {% assign specimenId = matchingSpecProcComp.procedure | to_json_string | generate_uuid -%}
+        {% endif %}
+        {% assign fullSpecimenId = specimenId | prepend: 'Specimen/' -%}
+        {% include 'Resource/Specimen' ID: specimenId, specimen: spec %}
         {% include 'Reference/Specimen/Subject' ID: specimenId, REF: fullPatientId -%}
         {% include 'Reference/DiagnosticReport/Specimen' ID: diagnosticID, REF: fullSpecimenId %}
     {% endfor %}

--- a/data/Templates/eCR/Entry/Result/_entry.liquid
+++ b/data/Templates/eCR/Entry/Result/_entry.liquid
@@ -16,52 +16,20 @@
         {% include 'Reference/DiagnosticReport/Performer' ID: diagnosticId, REF: fullPerformerId -%}
         {% endif -%}
     {% endif -%}
-    {% assign collectTime = null %}
-    {% if entry.organizer.effectiveTime.low and entry.organizer.effectiveTime.low.value -%}
-        {% assign collectTime = entry.organizer.effectiveTime.low.value -%}
-    {% elsif entry.organizer.effectiveTime.high and entry.organizer.effectiveTime.high.value -%}
-        {% assign collectTime = entry.organizer.effectiveTime.high.value -%}
-    {% elsif entry.organizer.effectiveTime and entry.organizer.effectiveTime.value and entry.organizer.effectiveTime.value != "UNK"-%}
-        {% assign collectTime = entry.organizer.effectiveTime.value -%}
-    {% endif -%}
-    
-    {% assign specValue = null %}
-    {% assign receiveTime = null %}
-    {% assign comps = entry.organizer.component | to_array -%}
-    {% for comp in comps -%}
-        {% if comp.procedure  -%}
-            {% if comp.procedure.entryRelationship and comp.procedure.entryRelationship.act -%}
-              {% assign acts = comp.procedure.entryRelationship.act | to_array %}
-              {% for act in acts -%}
-                {% if act.code and act.code["code"] == "SPRECEIVE" %}
-                  {% assign receiveTime = act.effectiveTime.value -%}
-                {% endif -%}
-              {% endfor -%} 
-            {% endif -%}
-            {% if comp.procedure.participant.participantRole.id -%}
-                {% assign playingEntity = comp.procedure.participant.participantRole.playingEntity -%}
-                {% if playingEntity.code.translation -%}
-                    {% assign translations = playingEntity.code.translation | to_array -%}
-                    {% if translations.first.displayName -%}
-                        {% assign specValue = translations.first.displayName -%}
-                    {% endif -%}
-                {% elsif comp.procedure.participant.participantRole.id.displayName -%}
-                    {% assign specValue = comp.procedure.participant.participantRole.id.displayName -%}
-                {% elsif playingEntity.code.originalText._ %}
-                    {% assign specValue = playingEntity.code.originalText._ -%}
-                {% elsif playingEntity.code.displayName -%}
-                     {% assign specValue = playingEntity.code.displayName -%}
-                {% endif -%}
-            {% endif -%}
-        {% endif -%}
-    {% endfor -%}   
+
+    {% assign procComponents  = entry.organizer.component | to_array | where: "procedure"  %}
+    {% for component in procComponents %}
+        {% assign specimenId = component.procedure | to_json_string | generate_uuid -%}
+        {% assign fullSpecimenId = specimenId | prepend: 'Specimen/' -%}
+        {% include 'Resource/Specimen' ID: specimenId, specimenProc: component.procedure %}
+        {% include 'Reference/Specimen/Subject' ID: specimenId, REF: fullPatientId -%}
+        {% include 'Reference/DiagnosticReport/Specimen' ID: diagnosticID, REF: fullSpecimenId %}
+    {% endfor %}
+
+    {% assign comps = entry.organizer.component | to_array -%} 
     {% for component in comps %}
         {% if component.observation.templateId.root != "2.16.840.1.113883.10.20.22.4.418" %} {% comment %} Ignore Laboratory Result Status observations {% endcomment %}
-            {% include 'Entry/Result/entry_organizer_component' with component, text: text, specValue: specValue, collectTime: collectTime, receiveTime: receiveTime, diagnosticId: diagnosticId %}
+            {% include 'Entry/Result/entry_organizer_component' with component, text: text, diagnosticId: diagnosticId %}
         {% endif %}
     {% endfor %}
 {% endif -%}
-{% comment %} Prevent weird variable leakage {% endcomment %}
-{% assign specValue = null %}
-{% assign receiveTime = null %}
-{% assign collectTime = null %}

--- a/data/Templates/eCR/Entry/Result/_entry_organizer_component.liquid
+++ b/data/Templates/eCR/Entry/Result/_entry_organizer_component.liquid
@@ -2,7 +2,7 @@
   {% if component.observation.code.nullFlavor and component.observation.code.nullFlavor != 'UNK' -%}
   {% else -%}
     {% assign observationId = component.observation | to_json_string | generate_uuid -%}
-    {% include 'Resource/Observation' observationCategory: 'laboratory', observationEntry: component.observation, ID: observationId, specimenValue: specValue, collectTime: collectTime, receiveTime: receiveTime, text: text -%}
+    {% include 'Resource/Observation' observationCategory: 'laboratory', observationEntry: component.observation, ID: observationId, text: text -%}
     {% assign fullObservationId = observationId | prepend: 'Observation/' -%}
     {% include 'Reference/DiagnosticReport/Result' ID: diagnosticId, REF: fullObservationId -%}
     {% include 'Reference/Observation/Subject' ID: observationId, REF: fullPatientId -%}

--- a/data/Templates/eCR/Resource/_DiagnosticReport.liquid
+++ b/data/Templates/eCR/Resource/_DiagnosticReport.liquid
@@ -21,9 +21,9 @@
             {% comment %} Laboratory Result Status: HL7 Result Status OBR-25 Result Status (HL701234_USL) {% endcomment %}
             "status":"{{ obsLabResultStatus.observation.value.code | get_property: 'ValueSet/DiagnosticReportStatus' }}",
         {% else -%}
-        {% comment %} If DNE, then use Mappings from one of the following: {% endcomment %}
-        {% comment %} 1) Result Status Value Set (V3 ActStatus): https://terminology.hl7.org/2.0.0/CodeSystem-v3-ActStatus.html {% endcomment %}
-        {% comment %} 2) FHIR R4 Diagnostic Report Status:  http://hl7.org/fhir/observation-status {% endcomment %}
+            {% comment %} If DNE, then use Mappings from one of the following: {% endcomment %}
+            {% comment %} 1) Result Status Value Set (V3 ActStatus): https://terminology.hl7.org/2.0.0/CodeSystem-v3-ActStatus.html {% endcomment %}
+            {% comment %} 2) FHIR R4 Diagnostic Report Status:  http://hl7.org/fhir/observation-status {% endcomment %}
             "status":"{{ diagnosticReport.statusCode.code | get_property: 'ValueSet/DiagnosticReportStatus' }}",
         {% endif %}
         "code":

--- a/data/Templates/eCR/Resource/_Observation.liquid
+++ b/data/Templates/eCR/Resource/_Observation.liquid
@@ -7,7 +7,12 @@
         {
             "profile":
             [
-                "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults",
+                {% case observationCategory %}
+                    {% when 'laboratory' %}
+                        "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-lab-result-observation",
+                    {% else %}
+                        "http://hl7.org/fhir/StructureDefinition/Observation"
+                {% endcase %}
             ],
         },
         "identifier":
@@ -36,8 +41,8 @@
             {% comment %} Mappings: https://build.fhir.org/ig/HL7/UTG/CodeSystem-v2-0085.html {% endcomment %}
             "status":"{{ observationEntry.entryRelationship.observation.value.code | get_property: 'ValueSet/ObservationResultStatus',  }}",
         {% else -%}
-        {% comment %} If DNE, then use Mappings from: Result Observation -  Result Status Value Set (V3 ActStatus) {% endcomment %}
-        {% comment %} Or from http://hl7.org/fhir/observation-status {% endcomment %}
+            {% comment %} If DNE, then use Mappings from: Result Observation -  Result Status Value Set (V3 ActStatus) {% endcomment %}
+            {% comment %} Or from http://hl7.org/fhir/observation-status {% endcomment %}
             "status":"{{ observationEntry.statusCode.code | get_property: 'ValueSet/ObservationResultStatus' }}",
         {% endif %}
         "code":
@@ -120,7 +125,7 @@
                                 {% include 'DataType/CodeableConcept' CodeableConcept: component.observation.code -%}
                             {% endif -%}
                         },
-                    "valueString": "{{ component.observation.value._ }}",
+                    {% include 'Utils/ValueHelper' value: component.observation.value %}
                     "extension": [
                         {% if component.observation.methodCode.originalText._ %}
                         {
@@ -133,7 +138,6 @@
                 {% endfor %}
             ],
         {% endif %}
-        {% comment %} TODO: can this go anywhere better? {% endcomment %}
         {% assign observationReferenceValue = observationEntry.text.reference.value | default: observationEntry.value.reference.value -%}
         "extension":
             [

--- a/data/Templates/eCR/Resource/_Observation.liquid
+++ b/data/Templates/eCR/Resource/_Observation.liquid
@@ -92,6 +92,7 @@
                         "unit":"{{ observationEntry.referenceRange.observationRange.value.high.translation.originalText._ }}",
                     },
                 {% endif -%}
+                "type": { {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.referenceRange.observationRange.interpretationCode %} },
             },
         ],
         "interpretation":
@@ -119,18 +120,15 @@
             [
                 {% for component in batteryComponents %}
                 {
-                    "code":
-                        {
-                            {% if component.observation.code -%}
-                                {% include 'DataType/CodeableConcept' CodeableConcept: component.observation.code -%}
-                            {% endif -%}
-                        },
+                    "code": {
+                        {% include 'DataType/CodeableConcept' CodeableConcept: component.observation.code -%}
+                    },
                     {% include 'Utils/ValueHelper' value: component.observation.value %}
                     "extension": [
-                        {% if component.observation.methodCode.originalText._ %}
+                        {% if component.observation.methodCode %}
                         {
-                            "url": "methodCode originalText",
-                            "valueString": "{{ component.observation.methodCode.originalText._ }}",
+                            "url": "methodCode",
+                            {% include 'Utils/ValueHelper' value: component.observation.methodCode %}
                         },
                         {% endif %}
                     ],

--- a/data/Templates/eCR/Resource/_Observation.liquid
+++ b/data/Templates/eCR/Resource/_Observation.liquid
@@ -137,7 +137,7 @@
         {% assign observationReferenceValue = observationEntry.text.reference.value | default: observationEntry.value.reference.value -%}
         "extension":
             [
-            {% if observationCategory == 'laboratory' and observationtReferenceValue %}
+            {% if observationCategory == 'laboratory' and observationReferenceValue %}
                 {
                     "url":"observation entry reference value",
                     "valueString":"{{ observationReferenceValue }}",

--- a/data/Templates/eCR/Resource/_Observation.liquid
+++ b/data/Templates/eCR/Resource/_Observation.liquid
@@ -134,22 +134,14 @@
             ],
         {% endif %}
         {% comment %} TODO: can this go anywhere better? {% endcomment %}
-        {% assign observationTextReferenceValue = observationEntry.text.reference.value -%}
-        {% assign observationValueReferenceValue = observationEntry.value.reference.value -%}
+        {% assign observationReferenceValue = observationEntry.text.reference.value | default: observationEntry.value.reference.value -%}
         "extension":
             [
-            {% if observationCategory == 'laboratory' %}
-                {% if observationTextReferenceValue -%}
-                    {
-                        "url":"observation entry reference value",
-                        "valueString":"{{ observationTextReferenceValue }}",
-                    },
-                {% elsif observationValueReferenceValue -%}
-                    {
-                        "url":"observation entry reference value",
-                        "valueString":"{{ observationValueReferenceValue }}",
-                    },
-                {% endif -%}
+            {% if observationCategory == 'laboratory' and observationtReferenceValue %}
+                {
+                    "url":"observation entry reference value",
+                    "valueString":"{{ observationReferenceValue }}",
+                },
             {% endif %}
             {% if observationEntry.entryRelationship.observation and observationEntry.entryRelationship.observation.templateId.root == '2.16.840.1.113883.10.20.22.4.419' %}
                 {% comment %} Lab Observation Result Status Extension {% endcomment %}

--- a/data/Templates/eCR/Resource/_Observation.liquid
+++ b/data/Templates/eCR/Resource/_Observation.liquid
@@ -133,46 +133,24 @@
                 {% endfor %}
             ],
         {% endif %}
+        {% comment %} TODO: can this go anywhere better? {% endcomment %}
         {% assign observationTextReferenceValue = observationEntry.text.reference.value -%}
         {% assign observationValueReferenceValue = observationEntry.value.reference.value -%}
         "extension":
-            [ {
-                {% if specimenValue != null or collectTime != null or receiveTime != null -%}
-
-                    "url" : "http://hl7.org/fhir/R4/specimen.html",
-                    "extension": [
-                    {% if specimenValue != null -%}
-                        {
-                            "url" : "specimen source",
-                            "valueString" : "{{ specimenValue }}",
-                        },
-                    {% endif -%}
-                    {% if collectTime != null -%}
-                        {
-                            "url" : "specimen collection time",
-                            "valueDateTime" : "{{ collectTime | format_as_date_time }}",
-                        },
-                    {% endif -%}
-                    {% if receiveTime != null -%}
-                        {
-                            "url" : "specimen receive time",
-                            "valueDateTime" : "{{ receiveTime | format_as_date_time }}",
-                        },
-                    {% endif -%}
-                    {% if observationTextReferenceValue -%}
-                        {
-                            "url":"observation entry reference value",
-                            "valueString":"{{ observationTextReferenceValue }}",
-                        },
-                    {% elsif observationValueReferenceValue -%}
-                        {
-                            "url":"observation entry reference value",
-                            "valueString":"{{ observationValueReferenceValue }}",
-                        },
-                    {% endif -%}
-                    ],
+            [
+            {% if observationCategory == 'laboratory' %}
+                {% if observationTextReferenceValue -%}
+                    {
+                        "url":"observation entry reference value",
+                        "valueString":"{{ observationTextReferenceValue }}",
+                    },
+                {% elsif observationValueReferenceValue -%}
+                    {
+                        "url":"observation entry reference value",
+                        "valueString":"{{ observationValueReferenceValue }}",
+                    },
                 {% endif -%}
-            },
+            {% endif %}
             {% if observationEntry.entryRelationship.observation and observationEntry.entryRelationship.observation.templateId.root == '2.16.840.1.113883.10.20.22.4.419' %}
                 {% comment %} Lab Observation Result Status Extension {% endcomment %}
                 {

--- a/data/Templates/eCR/Resource/_Specimen.liquid
+++ b/data/Templates/eCR/Resource/_Specimen.liquid
@@ -21,6 +21,8 @@
         {% endcomment %}
         {% assign obs = rels.observation %}
 
+        {% assign rejectReasons = obs | nested_where: 'templateId.root', '2.16.840.1.113883.10.20.22.4.420' %}
+        {{ rejectReasons | print_object }}
         {% assign rejected = false %}
         {% for ob in obs %}
             {% if ob.templateId.root == '2.16.840.1.113883.10.20.22.4.420' %}

--- a/data/Templates/eCR/Resource/_Specimen.liquid
+++ b/data/Templates/eCR/Resource/_Specimen.liquid
@@ -1,0 +1,79 @@
+{
+    "fullUrl":"urn:uuid:{{ ID }}",
+    "resource":{
+        "resourceType": "Specimen",
+        "id":"{{ ID }}",
+        "identifier":
+        [
+            {% assign ids = specimenProc.id | to_array -%}
+            {% for id in ids -%}
+            { {% include 'DataType/Identifier' Identifier: id -%} },
+            {% endfor -%}
+        ],
+        {% assign rels = specimenProc.entryRelationship | to_array %}
+        {% assign acts = rels.act %}
+        {% assign obs = rels.observation %}
+
+        {% assign rejected = false %}
+        {% for ob in obs %}
+            {% if ob.templateId.root == '2.16.840.1.113883.10.20.22.4.420' %}
+                {% assign rejected = true %}
+            {% endif %}
+        {% endfor %}
+        {% if rejected %}
+            "status": "unsatisfactory",
+        {% endif %}
+        "type": {
+            {% include 'DataType/CodeableConcept' CodeableConcept: specimenProc.participant.participantRole.playingEntity.code %}
+        },
+        {% assign receivedTime = nil %}
+        {% comment %} This is based on observed data and not per spec {% endcomment %}
+        {% for act in acts -%}
+            {% if act.code and act.code.code == "SPRECEIVE" %}
+                {% assign receivedTime = act.effectiveTime.value -%}
+            {% endif -%}
+        {% endfor -%} 
+        {% comment %} specimen observations generally are a loinc code and value. This is a guess at
+        what the spec-standard way of encoding received time is {% endcomment %}
+        {% for ob in obs %}
+            {% if ob.code.code == "63572-2" %}
+                {% assign receivedTime = ob.value.value -%}
+            {% endif %}
+        {% endfor %}
+        {% if receivedTime %}
+            "receivedTime": "{{ receivedTime | format_as_date_time }}",
+        {% endif %}
+        "collection": {
+            {% include 'Utils/EffectiveTime' timeType: "collected", effectiveTime: specimenProc.effectiveTime %}
+            "bodySite": {
+                {% include 'DataType/CodeableConcept' CodeableConcept: specimenProc.targetSiteCode %}
+            },
+        },
+        "condition": [
+        {% for ob in obs %}
+            {% if ob.templateId.root == '2.16.840.1.113883.10.20.22.4.421' %}
+                {
+                    {% include 'DataType/CodeableConcept' CodeableConcept: ob.value %}
+                },
+            {% endif %}
+        {% endfor %}
+        ],
+        "note": [
+        {% for act in acts %}
+            {% if act.templateId.root == '2.16.840.1.113883.10.20.22.4.64' %}
+                {% assign refVal = act.text.reference.value | replace: '#', '' -%}
+                {% assign commentStr = text | find_inner_text_by_id: refVal -%}
+                {
+                    "text": {{ commentStr | clean_string_from_tabs | escape_special_chars }},
+                    "time": "{{ act.author.time.value | format_as_date_time }}",
+                    "authorString": "{{ act.author.assignedAuthor.assignedPerson.name }}",
+                }
+            {% endif %}
+        {% endfor %}
+        ]
+    },
+    "request":{
+        "method":"PUT",
+        "url":"Specimen/{{ ID }}",
+    },
+},

--- a/data/Templates/eCR/Resource/_Specimen.liquid
+++ b/data/Templates/eCR/Resource/_Specimen.liquid
@@ -12,6 +12,13 @@
         ],
         {% assign rels = specimenProc.entryRelationship | to_array %}
         {% assign acts = rels.act %}
+        {% comment %}
+            NOTE: We are currently (potentially) not converting most data that comes through as
+            specimen observations. These are essentially code/value pairs of LOINC codes describing
+            what is observed and the result of that in the value. It can be any LOINC code and we
+            don't know where they would go. As these come in, we should start to find homes for them
+            in this resource.
+        {% endcomment %}
         {% assign obs = rels.observation %}
 
         {% assign rejected = false %}

--- a/data/Templates/eCR/Resource/_Specimen.liquid
+++ b/data/Templates/eCR/Resource/_Specimen.liquid
@@ -5,70 +5,23 @@
         "id":"{{ ID }}",
         "identifier":
         [
-            {% assign ids = specimenProc.id | to_array -%}
+            {% assign ids = specimen.specimenRole.id | to_array -%}
             {% for id in ids -%}
             { {% include 'DataType/Identifier' Identifier: id -%} },
             {% endfor -%}
         ],
-        {% assign rels = specimenProc.entryRelationship | to_array %}
-        {% assign acts = rels | where: 'act' | map: 'act' %}
-        {% comment %}
-            NOTE: We are currently (potentially) not converting most data that comes through as
-            specimen observations. These are essentially code/value pairs of LOINC codes describing
-            what is observed and the result of that in the value. It can be any LOINC code and we
-            don't know where they would go. As these come in, we should start to find homes for them
-            in this resource.
-        {% endcomment %}
-        {% assign obs = rels | where: 'observation' | map: 'observation' %}
-
-        {% assign rejectReason = obs | nested_where: 'templateId.root', '2.16.840.1.113883.10.20.22.4.420' | first %}
-        {% if rejectReason %}
-            "status": "unsatisfactory",
-        {% endif %}
         "type": {
-            {% include 'DataType/CodeableConcept' CodeableConcept: specimenProc.participant.participantRole.playingEntity.code %}
+            {% include 'DataType/CodeableConcept' CodeableConcept: specimen.specimenRole.specimenPlayingEntity.code %}
         },
-        {% assign receivedTime = nil %}
-        {% comment %} This is based on observed data and not per spec {% endcomment %}
-        {% assign receivedTimeAct = acts | nested_where: 'code.code', 'SPRECEIVE' | first %}
-        {% if receivedTimeAct -%}
-            {% assign receivedTime = receivedTimeAct.effectiveTime.value -%}
-        {% endif -%}
-        {% comment %} specimen observations generally are a loinc code and value. This is a guess at
-        what the spec-standard way of encoding received time is {% endcomment %}
-        {% assign receivedTimeObs = obs | nested_where: 'code.code', '63572-2' | first %}
-        {% if receivedTimeObs %}
-            {% assign receivedTime = receivedTimeObs.value.value -%}
-        {% endif %}
-        {% if receivedTime %}
-            "receivedTime": "{{ receivedTime | format_as_date_time }}",
-        {% endif %}
-        "collection": {
-            {% include 'Utils/EffectiveTime' timeType: "collected", effectiveTime: specimenProc.effectiveTime %}
-            "bodySite": {
-                {% include 'DataType/CodeableConcept' CodeableConcept: specimenProc.targetSiteCode %}
+        {% assign quantity = specimen.specimenRole.specimenPlayingEntity.quantity | to_array | first  %}
+        {% if quantity.value %}
+            "collection": {
+                "quantity": {
+                    "value": {{ quantity.value | format_quantity }},
+                    "unit": "{{ quantity.unit }}"
+                },
             },
-        },
-        "condition": [
-        {% assign conditionObs = obs | nested_where: 'templateId.root', '2.16.840.1.113883.10.20.22.4.421' %}
-        {% for ob in conditionObs %}
-            {
-                {% include 'DataType/CodeableConcept' CodeableConcept: ob.value %}
-            },
-        {% endfor %}
-        ],
-        "note": [
-        {% assign noteActs = acts | nested_where: 'templateId.root', '2.16.840.1.113883.10.20.22.4.64' %}
-        {% for act in noteActs %}
-            {% assign refVal = act.text.reference.value | replace: '#', '' -%}
-            {% assign commentStr = text | find_inner_text_by_id: refVal -%}
-            {
-                "text": {{ commentStr | clean_string_from_tabs | escape_special_chars }},
-                "time": "{{ act.author.time.value | format_as_date_time }}",
-                "authorString": "{{ act.author.assignedAuthor.assignedPerson.name }}",
-            }
-        {% endfor %}
-        ]
+        {% endif %}
     },
     "request":{
         "method":"PUT",

--- a/data/Templates/eCR/Resource/_Specimen.liquid
+++ b/data/Templates/eCR/Resource/_Specimen.liquid
@@ -11,7 +11,7 @@
             {% endfor -%}
         ],
         {% assign rels = specimenProc.entryRelationship | to_array %}
-        {% assign acts = rels.act %}
+        {% assign acts = rels | where: 'act' | map: 'act' %}
         {% comment %}
             NOTE: We are currently (potentially) not converting most data that comes through as
             specimen observations. These are essentially code/value pairs of LOINC codes describing
@@ -19,17 +19,10 @@
             don't know where they would go. As these come in, we should start to find homes for them
             in this resource.
         {% endcomment %}
-        {% assign obs = rels.observation %}
+        {% assign obs = rels | where: 'observation' | map: 'observation' %}
 
-        {% assign rejectReasons = obs | nested_where: 'templateId.root', '2.16.840.1.113883.10.20.22.4.420' %}
-        {{ rejectReasons | print_object }}
-        {% assign rejected = false %}
-        {% for ob in obs %}
-            {% if ob.templateId.root == '2.16.840.1.113883.10.20.22.4.420' %}
-                {% assign rejected = true %}
-            {% endif %}
-        {% endfor %}
-        {% if rejected %}
+        {% assign rejectReason = obs | nested_where: 'templateId.root', '2.16.840.1.113883.10.20.22.4.420' | first %}
+        {% if rejectReason %}
             "status": "unsatisfactory",
         {% endif %}
         "type": {
@@ -37,18 +30,16 @@
         },
         {% assign receivedTime = nil %}
         {% comment %} This is based on observed data and not per spec {% endcomment %}
-        {% for act in acts -%}
-            {% if act.code and act.code.code == "SPRECEIVE" %}
-                {% assign receivedTime = act.effectiveTime.value -%}
-            {% endif -%}
-        {% endfor -%} 
+        {% assign receivedTimeAct = acts | nested_where: 'code.code', 'SPRECEIVE' | first %}
+        {% if receivedTimeAct -%}
+            {% assign receivedTime = receivedTimeAct.effectiveTime.value -%}
+        {% endif -%}
         {% comment %} specimen observations generally are a loinc code and value. This is a guess at
         what the spec-standard way of encoding received time is {% endcomment %}
-        {% for ob in obs %}
-            {% if ob.code.code == "63572-2" %}
-                {% assign receivedTime = ob.value.value -%}
-            {% endif %}
-        {% endfor %}
+        {% assign receivedTimeObs = obs | nested_where: 'code.code', '63572-2' | first %}
+        {% if receivedTimeObs %}
+            {% assign receivedTime = receivedTimeObs.value.value -%}
+        {% endif %}
         {% if receivedTime %}
             "receivedTime": "{{ receivedTime | format_as_date_time }}",
         {% endif %}
@@ -59,25 +50,23 @@
             },
         },
         "condition": [
-        {% for ob in obs %}
-            {% if ob.templateId.root == '2.16.840.1.113883.10.20.22.4.421' %}
-                {
-                    {% include 'DataType/CodeableConcept' CodeableConcept: ob.value %}
-                },
-            {% endif %}
+        {% assign conditionObs = obs | nested_where: 'templateId.root', '2.16.840.1.113883.10.20.22.4.421' %}
+        {% for ob in conditionObs %}
+            {
+                {% include 'DataType/CodeableConcept' CodeableConcept: ob.value %}
+            },
         {% endfor %}
         ],
         "note": [
-        {% for act in acts %}
-            {% if act.templateId.root == '2.16.840.1.113883.10.20.22.4.64' %}
-                {% assign refVal = act.text.reference.value | replace: '#', '' -%}
-                {% assign commentStr = text | find_inner_text_by_id: refVal -%}
-                {
-                    "text": {{ commentStr | clean_string_from_tabs | escape_special_chars }},
-                    "time": "{{ act.author.time.value | format_as_date_time }}",
-                    "authorString": "{{ act.author.assignedAuthor.assignedPerson.name }}",
-                }
-            {% endif %}
+        {% assign noteActs = acts | nested_where: 'templateId.root', '2.16.840.1.113883.10.20.22.4.64' %}
+        {% for act in noteActs %}
+            {% assign refVal = act.text.reference.value | replace: '#', '' -%}
+            {% assign commentStr = text | find_inner_text_by_id: refVal -%}
+            {
+                "text": {{ commentStr | clean_string_from_tabs | escape_special_chars }},
+                "time": "{{ act.author.time.value | format_as_date_time }}",
+                "authorString": "{{ act.author.assignedAuthor.assignedPerson.name }}",
+            }
         {% endfor %}
         ]
     },

--- a/data/Templates/eCR/Resource/_SpecimenProcedure.liquid
+++ b/data/Templates/eCR/Resource/_SpecimenProcedure.liquid
@@ -1,0 +1,77 @@
+{
+    "fullUrl":"urn:uuid:{{ ID }}",
+    "resource":{
+        "resourceType": "Specimen",
+        "id":"{{ ID }}",
+        "identifier":
+        [
+            {% assign ids = specimenProc.participant.participantRole.id | to_array -%}
+            {% for id in ids -%}
+            { {% include 'DataType/Identifier' Identifier: id -%} },
+            {% endfor -%}
+        ],
+        {% assign rels = specimenProc.entryRelationship | to_array %}
+        {% assign acts = rels | where: 'act' | map: 'act' %}
+        {% comment %}
+            NOTE: We are currently (potentially) not converting most data that comes through as
+            specimen observations. These are essentially code/value pairs of LOINC codes describing
+            what is observed and the result of that in the value. It can be any LOINC code and we
+            don't know where they would go. As these come in, we should start to find homes for them
+            in this resource.
+        {% endcomment %}
+        {% assign obs = rels | where: 'observation' | map: 'observation' %}
+
+        {% assign rejectReason = obs | nested_where: 'templateId.root', '2.16.840.1.113883.10.20.22.4.420' | first %}
+        {% if rejectReason %}
+            "status": "unsatisfactory",
+        {% endif %}
+        "type": {
+            {% include 'DataType/CodeableConcept' CodeableConcept: specimenProc.participant.participantRole.playingEntity.code %}
+        },
+        {% assign receivedTime = nil %}
+        {% comment %} This is based on observed data and not per spec {% endcomment %}
+        {% assign receivedTimeAct = acts | nested_where: 'code.code', 'SPRECEIVE' | first %}
+        {% if receivedTimeAct -%}
+            {% assign receivedTime = receivedTimeAct.effectiveTime.value -%}
+        {% endif -%}
+        {% comment %} specimen observations generally are a loinc code and value. This is a guess at
+        what the spec-standard way of encoding received time is {% endcomment %}
+        {% assign receivedTimeObs = obs | nested_where: 'code.code', '63572-2' | first %}
+        {% if receivedTimeObs %}
+            {% assign receivedTime = receivedTimeObs.value.value -%}
+        {% endif %}
+        {% if receivedTime %}
+            "receivedTime": "{{ receivedTime | format_as_date_time }}",
+        {% endif %}
+        "collection": {
+            {% include 'Utils/EffectiveTime' timeType: "collected", effectiveTime: specimenProc.effectiveTime %}
+            "bodySite": {
+                {% include 'DataType/CodeableConcept' CodeableConcept: specimenProc.targetSiteCode %}
+            },
+        },
+        "condition": [
+        {% assign conditionObs = obs | nested_where: 'templateId.root', '2.16.840.1.113883.10.20.22.4.421' %}
+        {% for ob in conditionObs %}
+            {
+                {% include 'DataType/CodeableConcept' CodeableConcept: ob.value %}
+            },
+        {% endfor %}
+        ],
+        "note": [
+        {% assign noteActs = acts | nested_where: 'templateId.root', '2.16.840.1.113883.10.20.22.4.64' %}
+        {% for act in noteActs %}
+            {% assign refVal = act.text.reference.value | replace: '#', '' -%}
+            {% assign commentStr = text | find_inner_text_by_id: refVal -%}
+            {
+                "text": {{ commentStr | clean_string_from_tabs | escape_special_chars }},
+                "time": "{{ act.author.time.value | format_as_date_time }}",
+                "authorString": "{{ act.author.assignedAuthor.assignedPerson.name }}",
+            }
+        {% endfor %}
+        ]
+    },
+    "request":{
+        "method":"PUT",
+        "url":"Specimen/{{ ID }}",
+    },
+},

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/BaseConvertDataFunctionalTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/BaseConvertDataFunctionalTests.cs
@@ -238,7 +238,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests
                 //   4. whether the file should fail at parsing or validation when testing if valid (if it is fully valid, "validation" is what should be there)
                 //   5. The number of expected failures at the step in (4)
                 // ]
-                new[] { @"EICR", @"eCR_full.xml", @"eCR_full-expected.json", "validation", "19" },
+                new[] { @"EICR", @"eCR_full.xml", @"eCR_full-expected.json", "validation", "13" },
                 new[] { @"EICR", @"eCR_RR_combined_3_1.xml", @"eCR_RR_combined_3_1-expected.json", "parsing", "3" },
                 new[] { @"EICR", @"eCR_EveEverywoman.xml", @"eCR_EveEverywoman-expected.json", "parsing", "19" },
             };

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_EveEverywoman-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_EveEverywoman-expected.json
@@ -1816,6 +1816,15 @@
             "high": {
               "value": 44.5,
               "unit": "%"
+            },
+            "type": {
+              "coding": [
+                {
+                  "code": "L",
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                  "display": "Low"
+                }
+              ]
             }
           }
         ],
@@ -1890,6 +1899,15 @@
             "high": {
               "value": 4.8,
               "unit": "10*3/uL"
+            },
+            "type": {
+              "coding": [
+                {
+                  "code": "N",
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                  "display": "Normal"
+                }
+              ]
             }
           }
         ],
@@ -1998,6 +2016,15 @@
             "high": {
               "value": 45,
               "unit": "[iU]/mL"
+            },
+            "type": {
+              "coding": [
+                {
+                  "code": "N",
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                  "display": "Normal"
+                }
+              ]
             }
           }
         ],

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_EveEverywoman-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_EveEverywoman-expected.json
@@ -1607,6 +1607,11 @@
         "subject": {
           "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
         },
+        "specimen": [
+          {
+            "reference": "Specimen/f6ead144-a7d0-a2c9-2938-723d4c3c8fa6"
+          }
+        ],
         "result": [
           {
             "reference": "Observation/e333acb8-01e7-e1ea-e9bc-b87c9e8bfd7c"
@@ -1619,6 +1624,43 @@
       "request": {
         "method": "PUT",
         "url": "DiagnosticReport/d48a8db3-dcea-9283-8af5-68cf694ef489"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:f6ead144-a7d0-a2c9-2938-723d4c3c8fa6",
+      "resource": {
+        "resourceType": "Specimen",
+        "id": "f6ead144-a7d0-a2c9-2938-723d4c3c8fa6",
+        "type": {
+          "coding": [
+            {
+              "code": "119297000",
+              "system": "http://snomed.info/sct",
+              "display": "Blood specimen (specimen)"
+            }
+          ]
+        },
+        "collection": {
+          "collectedPeriod": {
+            "start": "2020-03-09"
+          },
+          "bodySite": {
+            "coding": [
+              {
+                "code": "368208006",
+                "system": "http://snomed.info/sct",
+                "display": "Left upper arm structure (body structure)"
+              }
+            ]
+          }
+        },
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Specimen/f6ead144-a7d0-a2c9-2938-723d4c3c8fa6"
       }
     },
     {
@@ -1682,21 +1724,6 @@
                 "code": "L",
                 "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
                 "display": "Low"
-              }
-            ]
-          }
-        ],
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/R4/specimen.html",
-            "extension": [
-              {
-                "url": "specimen source",
-                "valueString": "Blood specimen (specimen)"
-              },
-              {
-                "url": "specimen collection time",
-                "valueDateTime": "2020-11-07"
               }
             ]
           }
@@ -1771,21 +1798,6 @@
                 "code": "H",
                 "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
                 "display": "High"
-              }
-            ]
-          }
-        ],
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/R4/specimen.html",
-            "extension": [
-              {
-                "url": "specimen source",
-                "valueString": "Blood specimen (specimen)"
-              },
-              {
-                "url": "specimen collection time",
-                "valueDateTime": "2020-11-07"
               }
             ]
           }
@@ -1899,15 +1911,6 @@
           }
         ],
         "extension": [
-          {
-            "url": "http://hl7.org/fhir/R4/specimen.html",
-            "extension": [
-              {
-                "url": "specimen collection time",
-                "valueDateTime": "2020-11-07"
-              }
-            ]
-          },
           {
             "url": "http://terminology.hl7.org/ValueSet/v2-0085",
             "valueCodeableConcept": {
@@ -2032,15 +2035,6 @@
           }
         ],
         "extension": [
-          {
-            "url": "http://hl7.org/fhir/R4/specimen.html",
-            "extension": [
-              {
-                "url": "specimen collection time",
-                "valueDateTime": "2020-11-07"
-              }
-            ]
-          },
           {
             "url": "http://terminology.hl7.org/ValueSet/v2-0085",
             "valueCodeableConcept": {
@@ -2815,10 +2809,17 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:77d57bd0-c41e-78f4-cbbb-218b4a2c412a",
       "resource": {
         "resourceType": "Observation",
         "id": "77d57bd0-c41e-78f4-cbbb-218b4a2c412a",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/odh/StructureDefinition/odh-Employer-extension",
+            "valueReference": {
+              "reference": "Organization/3f173e4d-0ac7-bc1b-dd38-1df99c48640e"
+            }
+          }
+        ],
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/odh/StructureDefinition/odh-PastOrPresentJob"
@@ -2906,18 +2907,11 @@
             }
           }
         ],
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/us/odh/StructureDefinition/odh-Employer-extension",
-            "valueReference": {
-              "reference": "Organization/3f173e4d-0ac7-bc1b-dd38-1df99c48640e"
-            }
-          }
-        ],
         "subject": {
           "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
         }
       },
+      "fullUrl": "urn:uuid:77d57bd0-c41e-78f4-cbbb-218b4a2c412a",
       "request": {
         "method": "PUT",
         "url": "Observation/77d57bd0-c41e-78f4-cbbb-218b4a2c412a"

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_EveEverywoman-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_EveEverywoman-expected.json
@@ -1613,7 +1613,7 @@
         "id": "94fe2533-e208-a1b4-c510-c9ece8a2d490",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -1727,6 +1727,12 @@
       "resource": {
         "resourceType": "Specimen",
         "id": "f6ead144-a7d0-a2c9-2938-723d4c3c8fa6",
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:44fd0410-6115-4b8e-8ee9-a51b3817df66"
+          }
+        ],
         "type": {
           "coding": [
             {
@@ -1766,7 +1772,7 @@
         "id": "e333acb8-01e7-e1ea-e9bc-b87c9e8bfd7c",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-lab-result-observation"
           ]
         },
         "identifier": [
@@ -1840,7 +1846,7 @@
         "id": "4d749a1f-c826-e0c1-c5a8-4cdf22d35bd8",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-lab-result-observation"
           ]
         },
         "identifier": [
@@ -1953,7 +1959,7 @@
         "id": "9066312e-2cd6-fc9d-223e-090aa5e566d8",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-lab-result-observation"
           ]
         },
         "identifier": [
@@ -2075,7 +2081,7 @@
         "id": "d9915885-4dd6-2c75-851c-419cf0438d37",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-lab-result-observation"
           ]
         },
         "identifier": [
@@ -2215,7 +2221,7 @@
         "id": "580d8a11-769f-74d0-36f1-affd02d5975c",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -2273,7 +2279,7 @@
         "id": "a4052c7a-bd45-b9f6-46d5-2d7b646dde0a",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -2322,7 +2328,7 @@
         "id": "a1d4182f-0097-66b6-5bd2-64325b2cc715",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -2634,7 +2640,7 @@
         "id": "c241ed7b-dc3d-7055-5d3e-a307f8494b07",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -2688,7 +2694,7 @@
         "id": "962570d9-01a7-db34-f8c9-57168e44510d",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -3020,7 +3026,7 @@
         "id": "aa4503c3-c475-e3dd-96fa-814291526157",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -3077,7 +3083,7 @@
         "id": "daab0fc7-6a51-0e82-b16b-8541a088ec56",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -3127,7 +3133,7 @@
         "id": "8e60fc3c-0790-08ce-da9b-4da0bb028115",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -3177,7 +3183,7 @@
         "id": "c553f18d-9df3-590b-5900-acf75899ec21",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -3227,7 +3233,7 @@
         "id": "08747908-0c7e-9928-913d-65d7243d9487",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -3277,7 +3283,7 @@
         "id": "fb26676b-06f1-676c-acb2-458126dc6535",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -3327,7 +3333,7 @@
         "id": "a7226ec7-2e47-136b-c464-9ae6552f0a15",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -3377,7 +3383,7 @@
         "id": "38c6218f-8693-d40d-f1ce-5d345f32a553",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -3427,7 +3433,7 @@
         "id": "16e91e0a-8e11-7635-f67a-f0cc88395e8d",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -3477,7 +3483,7 @@
         "id": "5a2fdf42-c9cd-7938-6f1e-faceebac6f1c",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -3881,7 +3887,7 @@
         "id": "44e6df0f-4e41-63ee-2bda-625369930b7c",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -4008,7 +4014,7 @@
         "id": "ecf330de-e85f-0b34-5fdd-6dccdae41d6d",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
@@ -1674,6 +1674,14 @@
             "high": {
               "value": 500000,
               "unit": "10*3/uL"
+            },
+            "type": {
+              "coding": [
+                {
+                  "code": "N",
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation"
+                }
+              ]
             }
           }
         ],
@@ -1799,6 +1807,14 @@
             "high": {
               "value": 8,
               "unit": "ng/mL"
+            },
+            "type": {
+              "coding": [
+                {
+                  "code": "N",
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation"
+                }
+              ]
             }
           }
         ],

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
@@ -1522,6 +1522,12 @@
       "resource": {
         "resourceType": "Specimen",
         "id": "a0364c3a-0124-b1f1-c4f5-518c0d810ece",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.7.798268.300",
+            "value": "XX97036"
+          }
+        ],
         "type": {
           "coding": [
             {
@@ -1572,7 +1578,7 @@
         "id": "bcdfa648-971b-836c-5a7e-5eff675f405c",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-lab-result-observation"
           ]
         },
         "identifier": [
@@ -1628,7 +1634,7 @@
         "id": "607da054-fb30-24cc-7ad4-c551f3913320",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-lab-result-observation"
           ]
         },
         "identifier": [
@@ -1693,7 +1699,7 @@
         "id": "89ef1c4f-2ad2-ad2b-ff6c-145df1e8521a",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-lab-result-observation"
           ]
         },
         "identifier": [
@@ -1749,7 +1755,7 @@
         "id": "080f8e03-814d-d5b7-82a8-4788ce8e62ed",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-lab-result-observation"
           ]
         },
         "identifier": [
@@ -1818,7 +1824,7 @@
         "id": "5b1d7d64-ee1b-64e7-75a4-d7ff29fc9e77",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-lab-result-observation"
           ]
         },
         "identifier": [
@@ -1863,7 +1869,7 @@
         "id": "6350e7fb-da2f-eeab-75b8-c0e6ae25968f",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -1918,7 +1924,7 @@
         "id": "41173172-a928-8b21-a48d-d7d2156fe7ec",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -1978,7 +1984,7 @@
         "id": "699b9556-f7cb-9164-b312-849989c064a8",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -2038,7 +2044,7 @@
         "id": "e12e58c0-5b1c-ea6b-a474-26184e35bb54",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -2084,7 +2090,7 @@
         "id": "83f9f9b0-3066-d990-9b77-5144f5e60333",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -2170,7 +2176,7 @@
         "id": "06ab2e28-7e5d-3031-b644-29bd38bef2e8",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -2220,7 +2226,7 @@
         "id": "55b63b40-395c-6c58-dc5a-84d8fe84bfab",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -2270,7 +2276,7 @@
         "id": "66c220d3-6ce9-4cfd-bb8e-1efdfc035457",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -2320,7 +2326,7 @@
         "id": "7855a3c3-145b-158c-97f8-c4d6325d1b9b",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -2370,7 +2376,7 @@
         "id": "0c44d586-e6b0-2400-b615-fde6a667b249",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -2420,7 +2426,7 @@
         "id": "5c96eaaa-9117-bb37-58a0-64ae4dc1811c",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -2470,7 +2476,7 @@
         "id": "b30b4fc2-107e-c8d6-a5a7-a566656c0e0f",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -2520,7 +2526,7 @@
         "id": "826393fd-144f-86b4-5aa3-fd6a696c36cb",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -2570,7 +2576,7 @@
         "id": "ce6ae68e-af02-5134-0b92-5abc3a93791b",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -2625,7 +2631,7 @@
         "id": "c409dfdf-6a85-6710-cf2c-8287a88b2392",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -2675,7 +2681,7 @@
         "id": "66300dc8-8fc2-9c3b-b23d-4c8d9c398a39",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [
@@ -2730,7 +2736,7 @@
         "id": "6794b82a-7175-3150-38fb-9f5b295198eb",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
@@ -1486,6 +1486,14 @@
         "subject": {
           "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
         },
+        "specimen": [
+          {
+            "reference": "Specimen/a0364c3a-0124-b1f1-c4f5-518c0d810ece"
+          },
+          {
+            "reference": "Specimen/c625e261-fcd2-030c-7ddf-2145afdbb2a6"
+          }
+        ],
         "result": [
           {
             "reference": "Observation/bcdfa648-971b-836c-5a7e-5eff675f405c"
@@ -1507,6 +1515,54 @@
       "request": {
         "method": "PUT",
         "url": "DiagnosticReport/ce037697-81e6-973a-10e7-58d070f9f77b"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:a0364c3a-0124-b1f1-c4f5-518c0d810ece",
+      "resource": {
+        "resourceType": "Specimen",
+        "id": "a0364c3a-0124-b1f1-c4f5-518c0d810ece",
+        "type": {
+          "coding": [
+            {
+              "code": "119297000",
+              "system": "http://snomed.info/sct",
+              "display": "Blood"
+            }
+          ]
+        },
+        "collection": {
+          "bodySite": {
+            "coding": [
+              {
+                "code": "122555007",
+                "system": "http://snomed.info/sct",
+                "display": "Venous blood specimen (specimen)"
+              }
+            ]
+          }
+        },
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Specimen/a0364c3a-0124-b1f1-c4f5-518c0d810ece"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:c625e261-fcd2-030c-7ddf-2145afdbb2a6",
+      "resource": {
+        "resourceType": "Specimen",
+        "id": "c625e261-fcd2-030c-7ddf-2145afdbb2a6",
+        "subject": {
+          "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Specimen/c625e261-fcd2-030c-7ddf-2145afdbb2a6"
       }
     },
     {
@@ -1552,21 +1608,8 @@
         },
         "extension": [
           {
-            "url": "http://hl7.org/fhir/R4/specimen.html",
-            "extension": [
-              {
-                "url": "specimen source",
-                "valueString": "Blood"
-              },
-              {
-                "url": "specimen collection time",
-                "valueDateTime": "1981-10-16"
-              },
-              {
-                "url": "observation entry reference value",
-                "valueString": "#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp1"
-              }
-            ]
+            "url": "observation entry reference value",
+            "valueString": "#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp1"
           }
         ],
         "subject": {
@@ -1630,21 +1673,8 @@
         ],
         "extension": [
           {
-            "url": "http://hl7.org/fhir/R4/specimen.html",
-            "extension": [
-              {
-                "url": "specimen source",
-                "valueString": "Blood"
-              },
-              {
-                "url": "specimen collection time",
-                "valueDateTime": "1981-10-16"
-              },
-              {
-                "url": "observation entry reference value",
-                "valueString": "#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp2"
-              }
-            ]
+            "url": "observation entry reference value",
+            "valueString": "#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp2"
           }
         ],
         "subject": {
@@ -1699,21 +1729,8 @@
         },
         "extension": [
           {
-            "url": "http://hl7.org/fhir/R4/specimen.html",
-            "extension": [
-              {
-                "url": "specimen source",
-                "valueString": "Blood"
-              },
-              {
-                "url": "specimen collection time",
-                "valueDateTime": "1981-10-16"
-              },
-              {
-                "url": "observation entry reference value",
-                "valueString": "#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp3"
-              }
-            ]
+            "url": "observation entry reference value",
+            "valueString": "#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp3"
           }
         ],
         "subject": {
@@ -1781,21 +1798,8 @@
         ],
         "extension": [
           {
-            "url": "http://hl7.org/fhir/R4/specimen.html",
-            "extension": [
-              {
-                "url": "specimen source",
-                "valueString": "Blood"
-              },
-              {
-                "url": "specimen collection time",
-                "valueDateTime": "1981-10-16"
-              },
-              {
-                "url": "observation entry reference value",
-                "valueString": "#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp4"
-              }
-            ]
+            "url": "observation entry reference value",
+            "valueString": "#Result.1.2.840.114350.1.13.4304.2.7.2.798268.1072603.Comp4"
           }
         ],
         "subject": {
@@ -1843,21 +1847,6 @@
             }
           ]
         },
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/R4/specimen.html",
-            "extension": [
-              {
-                "url": "specimen source",
-                "valueString": "Blood"
-              },
-              {
-                "url": "specimen collection time",
-                "valueDateTime": "1981-10-16"
-              }
-            ]
-          }
-        ],
         "subject": {
           "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
         }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
@@ -876,17 +876,8 @@
         },
         "extension": [
           {
-            "url": "http://hl7.org/fhir/R4/specimen.html",
-            "extension": [
-              {
-                "url": "specimen collection time",
-                "valueDateTime": "2020-05-13"
-              },
-              {
-                "url": "observation entry reference value",
-                "valueString": "id_077fe949-6bbb-44b2-9430-f4f00cc4877d_ref"
-              }
-            ]
+            "url": "observation entry reference value",
+            "valueString": "id_077fe949-6bbb-44b2-9430-f4f00cc4877d_ref"
           }
         ],
         "subject": {
@@ -985,17 +976,8 @@
         },
         "extension": [
           {
-            "url": "http://hl7.org/fhir/R4/specimen.html",
-            "extension": [
-              {
-                "url": "specimen collection time",
-                "valueDateTime": "2020-05-15"
-              },
-              {
-                "url": "observation entry reference value",
-                "valueString": "id_5a3c1d72-9f88-41e7-b2d5-ec9a7f6b8c4f_ref"
-              }
-            ]
+            "url": "observation entry reference value",
+            "valueString": "id_5a3c1d72-9f88-41e7-b2d5-ec9a7f6b8c4f_ref"
           }
         ],
         "subject": {

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
@@ -835,7 +835,7 @@
         "id": "0e0093f9-e989-974c-eb83-21bfca5e42db",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-lab-result-observation"
           ]
         },
         "identifier": [
@@ -935,7 +935,7 @@
         "id": "cbf0c974-b864-e15a-b825-bfbf4708cc17",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-lab-result-observation"
           ]
         },
         "identifier": [
@@ -996,7 +996,7 @@
         "id": "7d4bbe54-856b-d831-d592-864f9da32c1d",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults"
+            "http://hl7.org/fhir/StructureDefinition/Observation"
           ]
         },
         "identifier": [

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/CustomFiltersTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/CustomFiltersTests.cs
@@ -388,4 +388,56 @@ public class CustomFilterTests
     var actual = Microsoft.Health.Fhir.Liquid.Converter.Filters.GetDiagnosisDictionary(CustomFilterTestFixtures.EncounterDiagnoses);
     Assert.Equal(new Dictionary<string, bool>() { { "B05.9", true }, { "B06.0", true }, { "B06.1", true } }, actual);
   }
+
+  [Fact]
+  public void NestedWhere_NullData_ReturnsNull()
+  {
+    var actual = Filters.NestedWhere(null, "test.path");
+    Assert.Equal(null, actual);
+  }
+
+  [Fact]
+  public void NestedWhere_EmptyArray_ReturnsEmpty()
+  {
+    var actual = Filters.NestedWhere(new object[] { }, "test.path");
+    Assert.Equal(new object[] { }, actual);
+  }
+
+  [Fact]
+  public void NestedWhere_NoMatch_ReturnsEmpty()
+  {
+    var actual = Filters.NestedWhere(
+      new object[] { new { test = "hi" }, new { test = "bye" } },
+      "test.path");
+    Assert.Equal(new object[] { }, actual);
+  }
+
+  [Fact]
+  public void NestedWhere_Match_ReturnsMatch()
+  {
+    var actual = Filters.NestedWhere(
+      new object[] { new { test = new { path = "hi" } }, new { test = "bye" } },
+      "test.path");
+    Assert.Equal(new object[] { new { test = new { path = "hi" } } }, actual);
+  }
+
+  [Fact]
+  public void NestedWhere_MatchButNotValue_ReturnsEmpty()
+  {
+    var actual = Filters.NestedWhere(
+      new object[] { new { test = new { path = "hi" } }, new { test = "bye" } },
+      "test.path",
+      "other");
+    Assert.Equal(new object[] { }, actual);
+  }
+
+  [Fact]
+  public void NestedWhere_MatchIncludingValue_ReturnsMatch()
+  {
+    var actual = Filters.NestedWhere(
+      new object[] { new { test = new { path = "hi" } }, new { test = "bye" } },
+      "test.path",
+      "hi");
+    Assert.Equal(new object[] { new { test = new { path = "hi" } } }, actual);
+  }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Resource/ObservationTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Resource/ObservationTests.cs
@@ -1,7 +1,10 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using DotLiquid;
 using Xunit;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Liquid.Converter.Parsers;
 
 namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests
 {
@@ -10,6 +13,110 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests
         private static readonly string ECRPath = Path.Join(
             TestConstants.ECRTemplateDirectory, "Resource", "_Observation.liquid"
         );
+
+        [Fact]
+        public void ObservationLab_Basic_AllFields()
+        {
+            // from 3.1 spec
+            var xmlStr = @"
+            <observation 
+                classCode=""OBS"" 
+                moodCode=""EVN""
+                xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance""
+                xsi:schemaLocation=""urn:hl7-org:v3 ../../../cda-core-2.0/schema/extensions/SDTC/infrastructure/cda/CDA_SDTC.xsd""
+                xmlns=""urn:hl7-org:v3""
+                xmlns:cda=""urn:hl7-org:v3""
+                xmlns:sdtc=""urn:hl7-org:sdtc""
+                xmlns:voc=""http://www.lantanagroup.com/voc""
+                >
+                <!-- [C-CDA R1.1] Result Observation -->
+                <templateId root=""2.16.840.1.113883.10.20.22.4.2"" />
+                <!-- [C-CDA R2.1] Result Observation (V3) -->
+                <templateId root=""2.16.840.1.113883.10.20.22.4.2"" extension=""2015-08-01"" />
+                <!-- [eICR R2 STU1.1] Initial Case Report Trigger Code Result Observation (V2) -->
+                <templateId root=""2.16.840.1.113883.10.20.15.2.3.2"" extension=""2019-04-01"" />
+                <id root=""bf9c0a26-4524-4395-b3ce-100450b9c9ad"" />
+                <!-- This code is a trigger code from RCTC subset:
+                    ""R4 Lab Obs Test Name Triggers for Public Health Reporting (RCTC subset)""
+                    @sdtc:valueSet and @sdtc:valueSetVersion shall be present -->
+                <code code=""11585-7""
+                    codeSystem=""2.16.840.1.113883.6.1""
+                    codeSystemName=""LOINC""
+                    displayName=""Bordetella pertussis Ab [Units/volume] in Serum""
+                    sdtc:valueSet=""2.16.840.1.114222.4.11.7508""
+                    sdtc:valueSetVersion=""2020-11-13"" />
+                <!-- statusCode is set to completed indicating that this is a final result -->
+                <statusCode code=""completed"" />
+                <effectiveTime value=""20201207"" />
+                <!-- This value is a physical quantity and thus cannot be a trigger code -->
+                <value xsi:type=""PQ"" unit=""[iU]/mL"" value=""100"" />
+                <!-- This interpretation code denotes that this patient value is above high normal -->
+                <interpretationCode code=""H""
+                    displayName=""High""
+                    codeSystem=""2.16.840.1.113883.5.83""
+                    codeSystemName=""ObservationInterpretation"" />
+                <referenceRange>
+                    <observationRange>
+                        <!-- Reference range: PT IgG: <45 IU/mL -->
+                        <value xsi:type=""IVL_PQ"">
+                        <high inclusive=""false"" unit=""[iU]/mL"" value=""45"" />
+                        </value>
+                        <!-- This interpretation code denotes that this reference range is for normal
+                        results.
+                        This is not the interpretation of a specific patient value-->
+                        <interpretationCode code=""N"" codeSystem=""2.16.840.1.113883.5.83"" displayName=""Normal""
+                        />
+                    </observationRange>
+                </referenceRange>
+                <text>
+                    <reference value=""#ipointtohtml""/>
+                </text>
+            </observation>
+            ";
+            var parsed = new CcdaDataParser().Parse(xmlStr) as Dictionary<string, object>;
+
+            var attributes = new Dictionary<string, object>
+            {
+                { "ID", "1234" },
+                { "observationCategory", "laboratory" },
+                { "observationEntry", parsed["observation"]},
+            };
+
+            var actualFhir = GetFhirObjectFromTemplate<Observation>(ECRPath, attributes);
+
+            Assert.Equal(ResourceType.Observation.ToString(), actualFhir.TypeName);
+            Assert.NotNull(actualFhir.Id);
+
+            Assert.Equal(ObservationStatus.Final, actualFhir.Status);
+
+            Assert.NotNull(actualFhir.Code);
+            Assert.Equal("Bordetella pertussis Ab [Units/volume] in Serum", actualFhir.Code?.Coding?.First().Display);
+            Assert.Equal("http://loinc.org", actualFhir.Code?.Coding?.First().System);
+
+
+            Assert.Equal("2020-12-07", (actualFhir.Effective as FhirDateTime)?.Value);
+
+            Assert.Equal("45", actualFhir.ReferenceRange.First().High.Value.ToString());
+            Assert.Equal("N", actualFhir.ReferenceRange.First().Type.Coding.First().Code);
+            Assert.Equal("H", actualFhir.Interpretation.First().Coding.First().Code);
+
+            Assert.IsType<Quantity>(actualFhir.Value);
+            var value = (Quantity)actualFhir.Value;
+
+            Assert.Equal("100", value.Value.ToString());
+            Assert.Equal("[iU]/mL", value.Unit);
+
+            Assert.Equal(
+                "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-lab-result-observation",
+                actualFhir.Meta.Profile.First());
+            Assert.Equal(
+                "laboratory",
+                actualFhir.Category.First().Coding.First().Code);
+
+            var refExt = actualFhir.Extension.First();
+            Assert.Equal("observation entry reference value", refExt.Url);
+            Assert.Equal("#ipointtohtml", refExt.Value.ToString());
+        }
 
         [Fact]
         public void Obs_Status_GivenLabObsResultStatus_ReturnsStatusFromObs()

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/CollectionFilters.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/CollectionFilters.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using DotLiquid;
+using DotLiquid.Util;
 using Microsoft.Health.Fhir.Liquid.Converter.DotLiquids;
 using Microsoft.Health.Fhir.Liquid.Converter.Exceptions;
 using Microsoft.Health.Fhir.Liquid.Converter.Models;
@@ -115,6 +116,33 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
             }
 
             return template;
+        }
+
+        private static bool HasMatchingPropertyRecursive(IList<IDictionary<string, object>> entry, string keyPath, string targetProperty = null)
+        {
+            var keys = keyPath.Split(".");
+            var res = DotLiquid.StandardFilters.Where(entry, keys[0], targetProperty) as IList<IDictionary<string, object>>;
+            if (res.Count() == 0)
+            {
+                return false;
+            }
+            else if (keys.Count() == 1)
+            {
+                return true;
+            }
+            else
+            {
+                return HasMatchingPropertyRecursive(new[] { res[0][keys[0]] }, keys[1..].Join('.'), targetProperty);
+            }
+        }
+
+        public static IList<IDictionary<string, object>> NestedWhere(IList<IDictionary<string, object>> entries, string keyPath, string targetProperty = null)
+        {
+            if (input == null)
+                return null;
+
+
+            return entries.Where(entry => HasMatchingPropertyRecursive(new[] { entry }, keyPath, targetProperty));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/CollectionFilters.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/CollectionFilters.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
         }
 
         /// <summary>
-        /// Given a collection, return items that match the keypath and target property (like standard 
+        /// Given a collection, return items that match the keypath and target property (like standard
         /// `where` filter except instead of taking one key, takes a period-delimited path of keys).
         /// </summary>
         /// <param name="entries">A collection of items.</param>

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/CustomFilters.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/CustomFilters.cs
@@ -351,7 +351,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
 
         Console.WriteLine($"{indent}}}");
       }
-      else if (obj is List<object> list)
+      else if (obj is IEnumerable<object> list)
       {
         Console.WriteLine($"{indent}[");
         foreach (var item in list)


### PR DESCRIPTION
* Get specimen information from either the result organizer's procedure or specimen (or both) and add as a standalone resource
* Reference the specimen from the `DiagnosticReport` and not the bespoke extensions in the `Observation`
* Add the type of the reference range when available
* Use the value helper in more places to add robustness to varied data
* move the `observation entry reference value` to a top level extension (I tried to find a better home for this, but failed)
* Use a valid profile on the observations always, and a more specific one for the case of lab
* Add a `nested_where` filter to make looking for elements that match a template/code nested inside it easier

Corresponding display PR: https://github.com/CDCgov/dibbs-ecr-viewer/pull/1019

fixes https://github.com/CDCgov/dibbs-ecr-viewer/issues/576
fixes https://github.com/CDCgov/dibbs-ecr-viewer/issues/996