### PR TITLE
test: only fail validation if it doesn't fail how we expect

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/BaseConvertDataFunctionalTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/BaseConvertDataFunctionalTests.cs
@@ -230,9 +230,17 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests
         {
             var data = new List<string[]>
             {
+                // Array has the following fields:
+                // [
+                //   1. Root template, 
+                //   2. ecr file, 
+                //   3. expected fhir file, 
+                //   4. whether the file should fail at parsing or validation when testing if valid (if it is fully valid, "validation" is what should be there)
+                //   5. The number of expected failures at the step in (4)
+                // ]
                 new[] { @"EICR", @"eCR_full.xml", @"eCR_full-expected.json", "validation", "19" },
                 new[] { @"EICR", @"eCR_RR_combined_3_1.xml", @"eCR_RR_combined_3_1-expected.json", "parsing", "3" },
-                new[] { @"EICR", @"eCR_EveEverywoman.xml", @"eCR_EveEverywoman-expected.json", "parsing", "16" },
+                new[] { @"EICR", @"eCR_EveEverywoman.xml", @"eCR_EveEverywoman-expected.json", "parsing", "19" },
             };
             return data.Select(item => new[]
             {

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/BaseConvertDataFunctionalTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/BaseConvertDataFunctionalTests.cs
@@ -414,6 +414,11 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests
                 var outcomeText = result.ToString();
                 var numFailed = result.Issue.Count();
 
+                if ("validation" == validationFailureStep && numFailures == numFailed)
+                {
+                    Console.WriteLine(result.ToString());
+                }
+
                 Assert.Equal("validation", validationFailureStep);
                 Assert.True(numFailures == numFailed, $"!!Validation failed!!\nExpected {numFailures}, but got {numFailed}\n{outcomeText}");
             }
@@ -422,6 +427,12 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests
 
                 var errors = e.Message.Replace(") (", ")\n(");
                 var numFailed = errors.Count(f => f == '\n') + 1;
+
+                if ("parsing" == validationFailureStep && numFailures == numFailed)
+                {
+                    Console.WriteLine(errors);
+                }
+
                 Assert.Equal("parsing", validationFailureStep);
                 Assert.True(numFailures == numFailed, $"!!Parsing failed!!\nExpected {numFailures}, but got {numFailed}\n{errors}");
                 return;

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/ConvertDataTemplateDirectoryProviderFunctionalTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/ConvertDataTemplateDirectoryProviderFunctionalTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests
                 rootTemplate,
                 inputFile,
                 validationFailureStep,
-                Int32.Parse(numFailures),
+                Int32.Parse(numFailures)
             );
         }
 

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/ConvertDataTemplateDirectoryProviderFunctionalTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/ConvertDataTemplateDirectoryProviderFunctionalTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests
 
         [Theory]
         [MemberData(nameof(GetDataForEcr))]
-        public void GivenEcrDocument_WhenConverting_ExpectedFhirResourceShouldBeReturned(string rootTemplate, string inputFile, string expectedFile)
+        public void GivenEcrDocument_WhenConverting_ExpectedFhirResourceShouldBeReturned(string rootTemplate, string inputFile, string expectedFile, string _validationFailureStep, string _numFailures)
         {
             var templateDirectory = Path.Join(AppDomain.CurrentDomain.BaseDirectory, Constants.TemplateDirectory, "eCR");
             var templateProvider = new TemplateProvider(templateDirectory, DataType.Ccda);
@@ -100,12 +100,18 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests
 
         [Theory]
         [MemberData(nameof(GetDataForEcr))]
-        public void GivenEcrDocument_WhenConverting_ExpectedFhirResourceShouldBeValid(string rootTemplate, string inputFile, string expectedFile)
+        public void GivenEcrDocument_WhenConverting_ExpectedFhirResourceShouldBeValid(string rootTemplate, string inputFile, string expectedFile, string validationFailureStep, string numFailures)
         {
             var templateDirectory = Path.Join(AppDomain.CurrentDomain.BaseDirectory, Constants.TemplateDirectory, "eCR");
             var templateProvider = new TemplateProvider(templateDirectory, DataType.Ccda);
 
-            ValidateConvertCCDAMessageIsValidFHIR(templateProvider, rootTemplate, inputFile);
+            ValidateConvertCCDAMessageIsValidFHIR(
+                templateProvider,
+                rootTemplate,
+                inputFile,
+                validationFailureStep,
+                Int32.Parse(numFailures),
+            );
         }
 
         [Theory]


### PR DESCRIPTION
Per discussion in standup, have validation pass if the type of failure (parsing vs validation) and number of failures is what we currently expect.

This means validation could fail because you've made things bettor or worse, but either way either you'll need to fix your code or update the expected failure mode in the `GetDataForEcr` method