### PR TITLE
refactor: Coding template creates valid object

### DIFF
--- a/data/Templates/eCR/DataType/_CodeableConcept.liquid
+++ b/data/Templates/eCR/DataType/_CodeableConcept.liquid
@@ -1,9 +1,9 @@
-"coding": 
+"coding":
 [
-	{% assign translations = CodeableConcept.translation | to_array -%}
-	{% assign concepts = CodeableConcept | to_array | concat: translations -%}
-	{% for concept in concepts -%}
-	{ {% include 'DataType/Coding' Coding: concept -%} },
-	{% endfor -%}
+  {% assign translations = CodeableConcept.translation | to_array -%}
+  {% assign concepts = CodeableConcept | to_array | concat: translations -%}
+  {% for concept in concepts -%}
+  {% include 'DataType/Coding' Coding: concept -%},
+  {% endfor -%}
 ],
 "text": "{{ CodeableConcept.originalText._ | clean_string_from_tabs | strip }}"

--- a/data/Templates/eCR/DataType/_Coding.liquid
+++ b/data/Templates/eCR/DataType/_Coding.liquid
@@ -1,16 +1,18 @@
-"code": "{{ Coding.code | strip }}",
-{%- capture codeSystemName -%}
-  {% include 'ValueSet/SystemReference' code: Coding.codeSystem %}
-{%- endcapture -%}
-"system": {{ codeSystemName }},
-{% if Coding.displayName -%}
-  "display": "{{ Coding.displayName | clean_string_from_tabs | strip }}",
-{% elsif Coding.originalText._ -%}
-  "display": "{{ Coding.originalText._ | clean_string_from_tabs | strip }}",
-{% elsif Coding.originalText.reference._ -%}
-  "display": "{{ Coding.originalText.reference._ }}",
-{% elsif codeSystemName contains "loinc" -%}
-  "display": "{{ Coding.code | get_loinc_name }}",
-{% elsif codeSystemName contains "rxnorm" -%}
-  "display": "{{ Coding.code | get_rxnorm_name }}",
-{% endif -%}
+{
+  "code": "{{ Coding.code | strip }}",
+  {%- capture codeSystemName -%}
+    {% include 'ValueSet/SystemReference' code: Coding.codeSystem %}
+  {%- endcapture -%}
+  "system": {{ codeSystemName }},
+  {% if Coding.displayName -%}
+    "display": "{{ Coding.displayName | clean_string_from_tabs | strip }}",
+  {% elsif Coding.originalText._ -%}
+    "display": "{{ Coding.originalText._ | clean_string_from_tabs | strip }}",
+  {% elsif Coding.originalText.reference._ -%}
+    "display": "{{ Coding.originalText.reference._ }}",
+  {% elsif codeSystemName contains "loinc" -%}
+    "display": "{{ Coding.code | get_loinc_name }}",
+  {% elsif codeSystemName contains "rxnorm" -%}
+    "display": "{{ Coding.code | get_rxnorm_name }}",
+  {% endif -%}
+}

--- a/data/Templates/eCR/Extension/_Ethnicity.liquid
+++ b/data/Templates/eCR/Extension/_Ethnicity.liquid
@@ -25,8 +25,8 @@
                         "url" : "ombCategory",
                     {% else -%}
                         "url" : "detailed",
-                    {% endif -%}                   
-                    "valueCoding" : { {% include 'DataType/Coding' Coding: e -%} },
+                    {% endif -%}
+                    "valueCoding" : {% include 'DataType/Coding' Coding: e -%},
                 {% endif -%}
             },
         {% endfor -%}
@@ -45,5 +45,5 @@
                 "valueString":"{{Ethnicity.ethnicGroupCode.displayName}}",
             {% endif -%}
         }
-    ],                        
+    ],
 {% endif -%}

--- a/data/Templates/eCR/Extension/_Race.liquid
+++ b/data/Templates/eCR/Extension/_Race.liquid
@@ -26,7 +26,7 @@
                     {% else -%}
                         "url" : "detailed",
                     {% endif -%}
-                    "valueCoding": { {% include 'DataType/Coding' Coding: r -%} },
+                    "valueCoding": {% include 'DataType/Coding' Coding: r -%},
                 {% endif -%}
             },
         {% endfor -%}

--- a/data/Templates/eCR/Extension/_TribalAffiliation.liquid
+++ b/data/Templates/eCR/Extension/_TribalAffiliation.liquid
@@ -3,8 +3,7 @@
     "extension" : [
         {
           "url" : "TribeName",
-          "valueCoding":
-                    { {% include 'DataType/Coding' Coding: tribeAOb.code -%} },
+          "valueCoding": {% include 'DataType/Coding' Coding: tribeAOb.code -%},
         },
         {% if tribeAOb.value -%}
           {

--- a/data/Templates/eCR/Resource/_Composition.liquid
+++ b/data/Templates/eCR/Resource/_Composition.liquid
@@ -299,9 +299,7 @@
                 ],
                 "code": {
                     "coding": [
-                        {
                             {% include 'DataType/Coding' Coding: composition.section.code -%}
-                        }
                     ],
                 },
                 "entry":

--- a/data/Templates/eCR/Resource/_Encounter.liquid
+++ b/data/Templates/eCR/Resource/_Encounter.liquid
@@ -9,11 +9,7 @@
         {% if encounter.statusCode.code == null -%}
         "status":"unknown",
         {% endif -%}
-        "class": {                
-                    {% if encounter.code -%}
-                        {% include 'DataType/Coding' Coding: encounter.code -%}
-                    {% endif -%}
-        },
+        "class": {% include 'DataType/Coding' Coding: encounter.code -%},
         "identifier":
         [
             {% assign ids = encounter.id | to_array -%}

--- a/data/Templates/eCR/Resource/_ObservationRREICRProcessingStatus.liquid
+++ b/data/Templates/eCR/Resource/_ObservationRREICRProcessingStatus.liquid
@@ -21,9 +21,9 @@
         "status":"final",
         "code":
         {
-            "coding": 
+            "coding":
             [
-                { {% include 'DataType/Coding' Coding: ob.code -%} },
+                {% include 'DataType/Coding' Coding: ob.code -%},
             ]
         },
         {% assign obEntryRelats = ob.entryRelationship | to_array -%}

--- a/data/Templates/eCR/Resource/_ObservationRREICRProcessingStatusReason.liquid
+++ b/data/Templates/eCR/Resource/_ObservationRREICRProcessingStatusReason.liquid
@@ -21,9 +21,9 @@
         "status":"final",
         "code":
         {
-            "coding": 
+            "coding":
             [
-                { {% include 'DataType/Coding' Coding: ob.code -%} },
+                {% include 'DataType/Coding' Coding: ob.code -%},
             ]
         },
         "valueCodeableConcept": {

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Templates/eCR/BaseECRLiquidTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Templates/eCR/BaseECRLiquidTests.cs
@@ -117,12 +117,16 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests
         {
             var actual = RenderLiquidTemplate(templatePath, attributes);
             var actualJson = DeserializeJson(actual);
-            var actualResource = actualJson.GetProperty("resource");
+
+            if (actualJson.TryGetProperty("resource", out var resourceElement))
+            {
+                actualJson = resourceElement;
+            }
 
             var fhirOptions = new JsonSerializerOptions { AllowTrailingCommas = true, }
                 .ForFhir(ModelInfo.ModelInspector)
                 .UsingMode(DeserializerModes.Ostrich);
-            var actualFhir = JsonSerializer.Deserialize<T>(actualResource, fhirOptions);
+            var actualFhir = JsonSerializer.Deserialize<T>(actualJson, fhirOptions);
 
             return actualFhir;
         }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Templates/eCR/DataType/CodingTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Templates/eCR/DataType/CodingTests.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.IO;
+using DotLiquid;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Liquid.Converter.Parsers;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests
+{
+    public class CodingTests : BaseECRLiquidTests
+    {
+        private static readonly string ECRPath = Path.Join(
+            TestConstants.ECRTemplateDirectory,
+            "DataType",
+            "_Coding.liquid"
+        );
+
+        [Fact]
+        public void GivenNoAttributeReturnsEmpty()
+        {
+            var attributes = new Dictionary<string, object> { { "Coding", "" }, };
+
+            var coding = GetFhirObjectFromTemplate<Coding>(ECRPath, attributes);
+
+            Assert.Empty(coding.System);
+            Assert.Empty(coding.Code);
+        }
+
+        [Fact]
+        public void AllFields()
+        {
+            var xmlString =
+                @"
+            <code
+                xmlns:sdtc=""urn:hl7-org:sdtc""
+                code=""385857005""
+                codeSystem=""2.16.840.1.113883.6.96""
+                codeSystemName=""SNOMED CT""
+                displayName=""Ventilator care and adjustment (regime/therapy)""
+                sdtc:valueSet=""2.16.840.1.114222.4.11.7508""
+                sdtc:valueSetVersion=""2020-11-13"" />
+            ";
+            var parsed = new CcdaDataParser().Parse(xmlString) as Dictionary<string, object>;
+            var attributes = new Dictionary<string, object> { { "Coding", parsed["code"] }, };
+
+            var coding = GetFhirObjectFromTemplate<Coding>(ECRPath, attributes);
+
+            Assert.Equal("http://snomed.info/sct", coding.System);
+            Assert.Equal("385857005", coding.Code);
+            Assert.Equal("Ventilator care and adjustment (regime/therapy)", coding.Display);
+        }
+    }
+}


### PR DESCRIPTION
Currently the `DataTypes/Coding` template does not include the surrounding brackets. This moves them into it so they do not have to be included where either the template is added. Add tests for `Coding` for good measure.