### PR TITLE
tests: Ignore datetime Formatting Parser Errors

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/BaseConvertDataFunctionalTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/BaseConvertDataFunctionalTests.cs
@@ -241,7 +241,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests
                 // ]
                 new[] { @"EICR", @"eCR_full.xml", @"eCR_full-expected.json", "validation", "13" },
                 new[] { @"EICR", @"eCR_RR_combined_3_1.xml", @"eCR_RR_combined_3_1-expected.json", "parsing", "1" },
-                new[] { @"EICR", @"eCR_EveEverywoman.xml", @"eCR_EveEverywoman-expected.json", "parsing", "7" },
+                new[] { @"EICR", @"eCR_EveEverywoman.xml", @"eCR_EveEverywoman-expected.json", "parsing", "3" },
             };
             return data.Select(item => new[]
             {


### PR DESCRIPTION
Ignores the datetime format parsing errors. 