### PR TITLE
fix: Handle medication administration effectiveDateTime when there is only one datetime.

### DIFF
--- a/data/SampleData/eCR/CDAR2_IG_PHCASERPT_R2_D2_SAMPLE.xml
+++ b/data/SampleData/eCR/CDAR2_IG_PHCASERPT_R2_D2_SAMPLE.xml
@@ -1,0 +1,2316 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    File:               CDAR2_IG_PHCASERPT_R2_D2_SAMPLE.xml
+    Specification:      Public Health Case Report, Release 1, STU Release 2 - US Realm
+
+    Created:            Eric M Haas, Health eData Inc, on behalf of HL7 PHER Working Group
+
+    Revision History:   11/09/2015              Eric M Haas     Pre-publication
+                        Oct-Dec 2018            Sarah Gaunt     Additions/Revisions for 1st update to STU Release 1 (Release 2, STU Release 1.1)
+                        Nov 2017                Sarah Gaunt     Updates
+                        Feb 2019                David deRoode   Update
+                        Mar 2019                Sarah Gaunt     Update
+                        Aug-Nov 2019            Sarah Gaunt     Update
+                        Jan 2020                Sarah Gaunt     Update for publication of STU2
+-->
+<!--
+    Disclaimer:
+    This sample file is informative only.
+    This sample file contains representative data elements from the eICR IG.
+    The file depicts a fictional character's health data. Any resemblance to a real person is coincidental.
+    To illustrate as many data elements as possible, the clinical scenario may not be entirely plausible.
+    The data in this sample file is not intended to represent a real patients, people or clinical events.
+    This sample is designed to be used in conjunction with the eICR IG.
+
+    Where guidance has been given to the conformance or cardinality of elements or
+    attributes and there is a discrepancy with the IG, the IG is always the normative
+    source of truth.
+
+    Please note:  This sample is valid against the Schema and Schematron for ERRORS (not warnings).
+    Logical schematron WARNINGS will generate from the sample file.
+    It is logical to generate a samples file from a system with valid warnings.
+-->
+<!--
+    Templates are identified in comments above their template id.
+    The IG in which the template version was first published is identified in square brackets before the template name.
+
+    e.g.: [C-CDA 2.1] Continuity of Care (CCD) (V3)       indicates that the Discharge Summary (V3) template was first published in IG C-CDA R2.1
+          [C-CDA R2.0] Plan of Treatment Section (V2)     indicates that the Plan of Treatment Section (V2) template was first published in IG C-CDA R2.0
+          [C-CDA R1.1] History of Present Illness Section indicates that the Hospital Course Section was first published in IG C-CDA R1.1
+
+    Even though all 3 templates above are included in IG C-CDA 2.1, because there have been no new versions of
+    the History of Present Illness Section template in IGs later than C-CDA R1.1, it is considered to be published in R1.1.
+    Similarly, there have been no new versions of the Plan of Treatment Section template later than C-CDA R.2 so it
+    is considered to be published in R2.0.
+-->
+<!--
+    While assertion of conformance with both C-CDA R2.1 and C-CDA R1.1 is NOT a requirement of the eICR IG, it is recommended that, if the
+    originating system includes both the versioned and un-versioned templateId, then both these templateIds SHOULD be preserved in the eICR document.
+    The examples and sample file included with this IG illustrate the optional use of the C-CDA R1.1 templateId.
+-->
+<?xml-stylesheet type="text/xsl" href="../../transform/CDAR2_eCR_eICR.xsl"?>
+<ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:hl7-org:v3" xmlns:cda="urn:hl7-org:v3"
+  xmlns:sdtc="urn:hl7-org:sdtc" xmlns:voc="http://www.lantanagroup.com/voc">
+  <!--
+        ********************************************************
+        CDA Header
+        ********************************************************
+    -->
+  <!-- US Realm Header template -->
+  <realmCode code="US" />
+  <typeId extension="POCD_HD000040" root="2.16.840.1.113883.1.3" />
+  <!-- [C-CDA R1.1] US Realm Header -->
+  <templateId root="2.16.840.1.113883.10.20.22.1.1" />
+  <!-- [C-CDA R2.1] US Realm Header (V3) -->
+  <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01" />
+  <!-- [eICR R2 STU2] Initial Public Health Case Report Document (eICR) (V3) -->
+  <templateId root="2.16.840.1.113883.10.20.15.2" extension="2019-04-01" />
+  <!-- Globally unique document ID (extension) is scoped by vendor/software -->
+  <id root="2.16.840.1.113883.9.9.9.9.9" extension="db734647-fc99-424c-a864-7e3cda82e704" />
+  <!-- Document Code -->
+  <code code="55751-2" codeSystem="2.16.840.1.113883.6.1" displayName="Public Health Case Report" />
+  <title>Initial Public Health Case Report</title>
+  <effectiveTime value="20181107094421-0500" />
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" displayName="Normal" />
+  <languageCode code="en-US" />
+
+  <setId root="2.16.840.1.113883.3.117.1.1.5.2.1.1.1" extension="31" />
+  <!-- the second in the series -->
+  <versionNumber value="2" />
+
+  <!--
+        ********************************************************
+        recordTarget: The patient
+        ********************************************************
+    -->
+  <recordTarget>
+    <!-- Patient demographic information -->
+    <patientRole>
+      <!-- Fake root for sample -->
+      <id extension="123453" root="2.16.840.1.113883.19.5" />
+      <!--SSN-->
+      <id extension="444-22-2222" root="2.16.840.1.113883.4.1" />
+      <!-- For greatest utility to public health, a patient's address
+        should be a home address if available (PostalAddressUse = 'H' or 'HP');
+        would also request a second address, preferably a work address,
+        (PostalAddressUse='WP') if available.
+
+        If the patient is homeless, complete as much address information
+        as possible (city, zip, county, etc.) and use the
+        Characteristics of Home Environment template in the
+        Social History Section to indicate that the patient is homeless. -->
+      <addr use="H">
+        <streetAddressLine>2222 Home Street</streetAddressLine>
+        <city>Ann Arbor</city>
+        <state>MI</state>
+        <postalCode>99999</postalCode>
+        <!-- Although "county" is not explicitly specified in the
+          US Realm Address, it is not precluded from use and for
+          the purposes of this IG it SHOULD be included.
+          See the IG for more information. -->
+        <county>26001</county>
+        <country>US</country>
+      </addr>
+      <telecom use="HP" value="tel:+1-555-555-2003" />
+      <telecom use="WP" value="tel:+1-555-555-2004" />
+      <patient>
+        <name use="L">
+          <given>Eve</given>
+          <given qualifier="IN">H</given>
+          <family>Everywoman</family>
+        </name>
+        <name use="A">
+          <given>Ruth</given>
+          <given qualifier="IN">L</given>
+          <family>Everywoman</family>
+        </name>
+        <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1" />
+        <birthTime value="19741124" />
+        <!-- If sdtc:deceasedInd is true then sdtc:deceasedTime must be present -->
+        <sdtc:deceasedInd value="false" />
+        <raceCode code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="White" />
+        <ethnicGroupCode code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="Not Hispanic or Latino" />
+        <!-- Parent/Guardian information-->
+        <guardian>
+          <!-- Parent/Guardian Address -->
+          <addr use="H">
+            <streetAddressLine>4444 Home Street</streetAddressLine>
+            <city>Ann Arbor</city>
+            <state>MI</state>
+            <postalCode>99999</postalCode>
+            <country>US</country>
+          </addr>
+          <!-- Parent/Guardian phone -->
+          <telecom use="HP" value="tel:+1-555-555-2006" />
+          <!-- Parent/Guardian email -->
+          <telecom value="mailto:mail@guardian.com" />
+          <guardianPerson>
+            <!-- Parent/guardian name -->
+            <name use="L">
+              <given>Martha</given>
+              <given qualifier="IN">L</given>
+              <family>Mum</family>
+            </name>
+          </guardianPerson>
+        </guardian>
+        <languageCommunication>
+          <languageCode code="en" />
+          <modeCode code="ESP" codeSystem="2.16.840.1.113883.5.60" codeSystemName="LanguageAbilityMode" displayName="Expressed spoken" />
+          <proficiencyLevelCode code="G" codeSystem="2.16.840.1.113883.5.61" codeSystemName="LanguageAbilityProficiency" displayName="Good" />
+          <!-- Preferred Language -->
+          <preferenceInd value="true" />
+        </languageCommunication>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <!--
+        ********************************************************
+        author
+        ********************************************************
+    -->
+  <author>
+    <time value="20181107094421-0500" />
+    <!--Author/authenticator may be software or may be a provider such as "infection control professional".-->
+    <assignedAuthor>
+      <!--Id for authoring device - made up application OID-->
+      <id root="2.16.840.1.113883.3.72.5.20" />
+      <!--authoring device address - may or may not be same as facility where care provided for case-->
+      <addr>
+        <streetAddressLine>1002 Healthcare Drive</streetAddressLine>
+        <city>Ann Arbor</city>
+        <state>MI</state>
+        <postalCode>99999</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom use="WP" value="tel:+1-(555)555-1212;ext=9998" />
+      <assignedAuthoringDevice>
+        <manufacturerModelName displayName="Acme" />
+        <softwareName displayName="Acme EHR" />
+      </assignedAuthoringDevice>
+    </assignedAuthor>
+  </author>
+  <!--
+        ********************************************************
+        custodian: The custodian of the CDA document is the generator of the document
+        ********************************************************
+    -->
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id extension="88888888" root="2.16.840.1.113883.4.6" />
+        <name>Good Health Hospital</name>
+        <telecom use="WP" value="tel:+1(555)555-1212" />
+        <addr>
+          <streetAddressLine>1000 Hospital Lane</streetAddressLine>
+          <city>Ann Arbor</city>
+          <state>MI</state>
+          <postalCode>99999</postalCode>
+          <country>US</country>
+        </addr>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+
+  <!--
+        ********************************************************
+        relatedDocument: the document with which to replace this document
+        ********************************************************
+    -->
+  <!-- Replace version 1 of this document -->
+  <relatedDocument typeCode="RPLC">
+    <parentDocument>
+      <!-- ClinicalDocument/id of the document to replace -->
+      <id root="2.16.840.1.113883.9.9.9.9.9" extension="db734647-fc99-424c-a864-7e3cda82e704" />
+      <!-- setId of the document to replace -->
+      <setId root="2.16.840.1.113883.3.117.1.1.5.2.1.1.1" extension="31" />
+      <!-- versionNumber of the document to replace -->
+      <versionNumber value="1" />
+    </parentDocument>
+  </relatedDocument>
+  <!--
+        ********************************************************
+        componentOf: contains the encompassingEncouter and the
+        provider and facility infomation for the case
+        ********************************************************
+    -->
+  <componentOf>
+    <encompassingEncounter>
+      <!--encounter ID-->
+      <id extension="9937012" root="2.16.840.1.113883.19" />
+      <!-- Where a trigger occurs outside of an encounter use
+              code="PHC2237" |
+              codeSystem="2.16.840.1.114222.4.5.274" |
+              codeSystemName="PHIN VS (CDC Local Coding System)"
+              (External Historical Encounter)
+           and set effectiveTime/low/@nullFlavor="NA" and omit responsibleParty and location. -->
+      <!--ActClassEncounterCodes -->
+      <code code="AMB" codeSystem="2.16.840.1.113883.5.4" codeSystemName="HL7 ActEncounterCode" displayName="Ambulatory"/>
+        <!--      <code code="PHC2237" codeSystem="2.16.840.1.114222.4.5.274" codeSystemName="PHIN VS (CDC Local Coding System)" displayName="External Historical Encounter">-->
+      <effectiveTime>
+        <low value="20181107" />
+      </effectiveTime>
+      <!--provider in charge of care when case reported-->
+      <responsibleParty>
+        <assignedEntity>
+          <id extension="6666666666666" root="2.16.840.1.113883.4.6" />
+          <addr>
+            <streetAddressLine>1002 Healthcare Drive</streetAddressLine>
+            <city>Ann Arbor</city>
+            <state>MI</state>
+            <postalCode>99999</postalCode>
+            <country>US</country>
+          </addr>
+          <!-- Provider Phone -->
+          <telecom use="WP" value="tel:+1(555)555-1003" />
+          <!-- Provider Fax -->
+          <telecom use="WP" value="fax:+1(555)555-1234" />
+          <!-- Provider Email -->
+          <telecom use="WP" value="mailto:mail@provider_domain.com" />
+          <assignedPerson>
+            <!-- Provider Name -->
+            <name>
+              <given>Henry</given>
+              <family>Seven</family>
+              <suffix qualifier="AC">M.D.</suffix>
+            </name>
+          </assignedPerson>
+          <representedOrganization>
+            <!-- Provider Facility/Office Name -->
+            <name>Community Health and Hospitals</name>
+            <!-- Provider Address -->
+            <addr>
+              <streetAddressLine>1002 Healthcare Drive</streetAddressLine>
+              <city>Ann Arbor</city>
+              <state>MI</state>
+              <postalCode>99999</postalCode>
+              <country>US</country>
+            </addr>
+          </representedOrganization>
+        </assignedEntity>
+      </responsibleParty>
+      <!-- Information about facility where care was provided when case reported-->
+      <location>
+        <healthCareFacility>
+          <id extension="77777777777" root="2.16.840.1.113883.4.6" />
+          <!-- Facility Type-->
+          <code code="OF" codeSystem="2.16.840.1.113883.5.111" displayName="Outpatient facility" />
+          <!-- Facility location within larger healthcare organization e.g Kaiser Vacaville within Kaiser North-->
+          <location>
+            <addr>
+              <streetAddressLine>1000 Hospital Lane</streetAddressLine>
+              <city>Ann Arbor</city>
+              <state>MI</state>
+              <postalCode>99999</postalCode>
+              <country>US</country>
+            </addr>
+          </location>
+          <!--Facility contact information-->
+          <serviceProviderOrganization>
+            <!-- Facility Name -->
+            <name>Good Health Hospital</name>
+            <!-- Facility Phone -->
+            <telecom use="WP" value="tel: 1+(555)-555-1212" />
+            <!-- Facility Fax -->
+            <telecom use="WP" value="fax: 1+(555)-555-3333" />
+            <!-- Facility Addr -->
+            <addr>
+              <streetAddressLine>1000 Hospital Lane</streetAddressLine>
+              <city>Ann Arbor</city>
+              <state>MI</state>
+              <postalCode>99999</postalCode>
+              <country>US</country>
+            </addr>
+          </serviceProviderOrganization>
+        </healthCareFacility>
+      </location>
+    </encompassingEncounter>
+  </componentOf>
+  <component>
+    <structuredBody>
+      <!--
+          ********************************************************
+          Plan of Treatment Section (V2)
+          ********************************************************
+      -->
+      <component>
+        <section>
+          <!-- [C-CDA R1.1] Plan of Care Section -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.22.10" />
+          <!-- [C-CDA R2.0] Plan of Treatment Section (V2) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.22.10" extension="2014-06-09" />
+          <code code="18776-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Plan of Treatment" />
+          <title>Plan of Treatment</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Initial Case Report Trigger<br />Code Lab Test Order</th>
+                  <th>Trigger Code</th>
+                  <th>Trigger Code codeSystem</th>
+                  <th>RCTC OID</th>
+                  <th>RCTC Version</th>
+                  <th>Ordered Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr ID="id_b52bee94-c34b-4e2c-8c15-5ad9d6def205_ref">
+                  <td>Zika virus envelope (E) gene [Presence] in Serum<br />by Probe and target amplification method</td>
+                  <td>80825-3</td>
+                  <td>LOINC</td>
+                  <td>2.16.840.1.114222.4.11.7508</td>
+                  <td>19/05/2018</td>
+                  <td>NOV 8, 2018</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <entry typeCode="DRIV">
+            <!-- This is a request for a test to be performed (a lab test order) -->
+            <observation classCode="OBS" moodCode="RQO">
+              <!-- [C-CDA R1.1] Plan of Care Activity Observation -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.44" />
+              <!-- [C-CDA R2.0] Planned Observation (V2) -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.44" extension="2014-06-09" />
+              <!-- [eICR R2 STU2] Initial Case Report Trigger Code Lab Test Order (V2) -->
+              <templateId root="2.16.840.1.113883.10.20.15.2.3.4" extension="2019-04-01" />
+              <id root="b52bee94-c34b-4e2c-8c15-5ad9d6def205" />
+              <!-- This code is from the trigger codes for laboratory test order
+                   value set (2.16.840.1.113762.1.4.1146.166) -->
+              <code code="80825-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                displayName="Zika virus envelope (E) gene [Presence] in Serum by Probe and target amplification method" sdtc:valueSet="2.16.840.1.114222.4.11.7508"
+                sdtc:valueSetVersion="12/12/2018" />
+              <statusCode code="active" />
+              <!-- Date on which the lab test should take place -->
+              <effectiveTime value="20181108" />
+            </observation>
+          </entry>
+        </section>
+      </component>
+      <!--
+                ********************************************************
+                Encounters Section (entries required) (V3)
+                ********************************************************
+            -->
+      <component>
+        <section>
+          <!-- [C-CDA R1.1] Encounters Section (entries optional) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.22" />
+          <!-- [C-CDA R2.1] Encounters Section (entries optional) (V3) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.22" extension="2015-08-01" />
+          <!-- [C-CDA R1.1] Encounters Section (entries required) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.22.1" />
+          <!-- [C-CDA R2.1] Encounters Section (entries required) (V3) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.22.1" extension="2015-08-01" />
+          <code code="46240-8" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="History of encounters" />
+          <title>Encounters</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Encounter</th>
+                  <th>Date(s)</th>
+                  <th>Location</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr ID="id_2a620155-9d11-439e-92b3-5d9815ff4de8_ref">
+                  <td>Office outpatient visit 15 minutes</td>
+                  <td>NOV 7, 2018</td>
+                  <td>
+                    <list styleCode="none">
+                      <item>
+                        <content styleCode="Italics">Urgent Care Center</content>
+                      </item>
+                    </list>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="20">
+                    <list styleCode="none">
+                      <item>
+                        <table>
+                          <thead>
+                            <tr>
+                              <th>Encounter Diagnosis Type</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr>
+                              <td>Diagnosis</td>
+                            </tr>
+                            <tr>
+                              <td colspan="20">
+                                <list styleCode="none">
+                                  <item>
+                                    <table>
+                                      <thead>
+                                        <tr>
+                                          <th>Initial Case Report Trigger<br />Code Problem Observation </th>
+                                          <th>Problem</th>
+                                          <th>Trigger Code</th>
+                                          <th>Trigger Code codeSystem</th>
+                                          <th>RCTC OID</th>
+                                          <th>RCTC Version</th>
+                                          <th>Date(s)</th>
+                                        </tr>
+                                      </thead>
+                                      <tbody>
+                                        <tr ID="id_db734647-fc99-424c-a864-7e3cda82e705_ref">
+                                          <td>Diagnosis</td>
+                                          <td>Pertussis (disorder)</td>
+                                          <td>27836007</td>
+                                          <td>SNOMED CT</td>
+                                          <td>2.16.840.1.114222.4.11.7508</td>
+                                          <td>19/05/2018</td>
+                                          <td>NOV 7, 2018</td>
+                                        </tr>
+                                      </tbody>
+                                    </table>
+                                    <table>
+                                      <thead>
+                                        <tr>
+                                          <th>Encounter Diagnosis Type</th>
+                                        </tr>
+                                      </thead>
+                                      <tbody>
+                                        <tr>
+                                          <td>Diagnosis</td>
+                                        </tr>
+                                        <tr>
+                                          <td colspan="20">
+                                            <list styleCode="none">
+                                              <item>
+                                                <table>
+                                                  <thead>
+                                                    <tr>
+                                                      <th>Problem Type</th>
+                                                      <th>Problem</th>
+                                                      <th>Date(s)</th>
+                                                    </tr>
+                                                  </thead>
+                                                  <tbody>
+                                                    <tr ID="id_db734647-fc99-424c-a864-7e3cda82e704_ref">
+                                                      <td>Diagnosis</td>
+                                                      <td>A non-trigger code diagnosis (disorder)</td>
+                                                      <td>NOV 7, 2018</td>
+                                                    </tr>
+                                                  </tbody>
+                                                </table>
+                                              </item>
+                                            </list>
+                                          </td>
+                                        </tr>
+                                      </tbody>
+                                    </table>
+                                  </item>
+                                </list>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </item>
+                    </list>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <entry typeCode="DRIV">
+            <encounter classCode="ENC" moodCode="EVN">
+              <!-- [C-CDA R1.1] Encounter Activities-->
+              <templateId root="2.16.840.1.113883.10.20.22.4.49" />
+              <!-- [C-CDA R2.1] Encounter Activities (V3)-->
+              <templateId root="2.16.840.1.113883.10.20.22.4.49" extension="2015-08-01" />
+              <id root="2a620155-9d11-439e-92b3-5d9815ff4de8" />
+              <code code="99213" codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT-4" displayName="Office outpatient visit 15 minutes" />
+              <effectiveTime value="20181107" />
+              <entryRelationship typeCode="COMP">
+                <act classCode="ACT" moodCode="EVN">
+                  <!-- [C-CDA R1.1] Encounter Diagnosis -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.80" />
+                  <!-- [C-CDA R2.1] Encounter Diagnosis (V3) -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.80" extension="2015-08-01" />
+                  <code code="29308-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Diagnosis" />
+                  <entryRelationship typeCode="SUBJ">
+                    <observation classCode="OBS" moodCode="EVN" negationInd="false">
+                      <!-- [C-CDA R1.1] Problem Observation -->
+                      <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                      <!-- [C-CDA R2.1] Problem Observation (V3) -->
+                      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+                      <!-- [eICR R2 STU2] Initial Case Report Trigger Code Problem Observation (V2) -->
+                      <templateId root="2.16.840.1.113883.10.20.15.2.3.3" extension="2019-04-01" />
+                      <id root="db734647-fc99-424c-a864-7e3cda82e705" />
+                      <code code="29308-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Diagnosis">
+                        <translation code="282291009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Diagnosis" />
+                      </code>
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20181107" />
+                      </effectiveTime>
+                      <!-- Trigger code -->
+                      <value xsi:type="CD" code="27836007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Pertussis (disorder)"
+                        sdtc:valueSet="2.16.840.1.114222.4.11.7508" sdtc:valueSetVersion="12/12/2018" />
+                    </observation>
+                  </entryRelationship>
+                </act>
+              </entryRelationship>
+              <entryRelationship typeCode="COMP">
+                <act classCode="ACT" moodCode="EVN">
+                  <!-- [C-CDA R1.1] Encounter Diagnosis -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.80" />
+                  <!-- [C-CDA R2.1] Encounter Diagnosis (V3) -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.80" extension="2015-08-01" />
+                  <code code="29308-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Diagnosis" />
+                  <entryRelationship typeCode="SUBJ">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!-- [C-CDA R1.1] Problem Observation -->
+                      <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                      <!-- [C-CDA R2.1] Problem Observation (V3) -->
+                      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+                      <id root="db734647-fc99-424c-a864-7e3cda82e704" />
+                      <code code="29308-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Diagnosis">
+                        <translation code="282291009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Diagnosis" />
+                      </code>
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20181107" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="282291009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                        displayName="A non-trigger code diagnosis (disorder)" />
+                    </observation>
+                  </entryRelationship>
+                </act>
+              </entryRelationship>
+            </encounter>
+          </entry>
+        </section>
+      </component>
+      <!--
+                 ********************************************************
+                 History of Present Illness Section
+                 ********************************************************
+            -->
+      <component>
+        <section>
+          <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.4" />
+          <code code="10164-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="HISTORY OF PRESENT ILLNESS" />
+          <title>History of Present Illness</title>
+          <text mediaType="text/x-hl7-text+xml">
+            <paragraph> Persistent Cough REPORTED starting on 2018/10/05<br /> Whooping Respiration not reported<br /> Paroxysms Of
+                            Coughing REPORTED starting on 2018/11/04<br /> Post-tussive vomiting not reported<br />
+            </paragraph>
+          </text>
+        </section>
+      </component>
+      <!--
+                ********************************************************
+                Medications Administered Section (V2)
+                ********************************************************
+            -->
+      <component>
+        <section>
+          <!-- [C-CDA R1.1] Medications Administered Section -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.38" />
+          <!-- [C-CDA R2.0] Medications Administered Section (V2) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.38" extension="2014-06-09" />
+          <code code="29549-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Medications Administered" />
+          <title>Medications Administered</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Medication</th>
+                  <th>Dose</th>
+                  <th>Duration</th>
+                  <th>Route</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr ID="id_6c844c75-aa34-411c-b7bd-5e4a9f206e29_ref">
+                  <td>Azithromycin 500 MG Oral Tablet</td>
+                  <td>1 g</td>
+                  <td>NOV 7, 2018 11:60</td>
+                  <td>ORAL</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <entry typeCode="DRIV">
+            <substanceAdministration classCode="SBADM" moodCode="EVN">
+              <!-- [C-CDA R1.1] Medication Activity -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.16" />
+              <!-- [C-CDA R2.0] Medication Activity (V2) -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.16" extension="2014-06-09" />
+              <id root="6c844c75-aa34-411c-b7bd-5e4a9f206e29" />
+              <statusCode code="completed" />
+              <effectiveTime xsi:type="IVL_TS" operator="A" value="201811071200-0700" />
+              <routeCode code="C38288" codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI Thesaurus" displayName="ORAL" />
+              <!--              <doseQuantity value="1" unit="g" />-->
+              <doseQuantity nullFlavor="NA" />
+              <consumable>
+                <manufacturedProduct classCode="MANU">
+                  <!-- [C-CDA R2.0] Medication Information (V2) -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.23" extension="2014-06-09" />
+                  <!-- [eICR R2 STU2] Initial Case Report Trigger Code Medication Information -->
+                  <templateId root="2.16.840.1.113883.10.20.15.2.3.36" extension="2019-04-01" />
+                  <id root="2a620155-9d11-439e-92b3-5d9815ff4ee8" />
+                  <manufacturedMaterial>
+                    <code code="248656" codeSystem="2.16.840.1.113883.6.88" codeSystemName="RxNorm" displayName="Azithromycin 500 MG Oral Tablet"
+                      sdtc:valueSet="2.16.840.1.114222.4.11.7508" sdtc:valueSetVersion="12/12/2018" />
+                  </manufacturedMaterial>
+                </manufacturedProduct>
+              </consumable>
+              <entryRelationship typeCode="CAUS">
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [eICR R2] Therapeutic Medication Response Observation -->
+                  <templateId root="2.16.840.1.113883.10.20.15.2.3.37" extension="2019-04-01" />
+                  <id root="ab1791b0-5c71-11db-b0de-0800200c9a55" />
+                  <code code="67540-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Response to medication" />
+                  <statusCode code="completed" />
+                  <effectiveTime>
+                    <low value="20181101" />
+                  </effectiveTime>
+                  <value code="268910001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Patient's condition improved (finding)"
+                    xsi:type="CD" />
+                </observation>
+              </entryRelationship>
+            </substanceAdministration>
+          </entry>
+        </section>
+      </component>
+      <!--
+          ********************************************************
+          Problem Section (entries required) (V3)
+          ********************************************************
+      -->
+      <component>
+        <section>
+          <!-- [C-CDA R1.1] Problem Section (entries optional) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.5" />
+          <!-- [C-CDA R2.1] Problem Section (entries optional) (V3) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.5" extension="2015-08-01" />
+          <!-- [C-CDA R1.1] Problem Section (entries required) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.5.1" />
+          <!-- [C-CDA R2.1] Problem Section (entries required) (V3) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.5.1" extension="2015-08-01" />
+          <code code="11450-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Problem List" />
+          <title>Problems</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Concern</th>
+                  <th>Concern Status</th>
+                  <th>Date(s)</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr ID="id_ec8a6ff8-ed4b-4f7e-82c3-e98e58b45de7_ref">
+                  <td>Problem</td>
+                  <td>active</td>
+                  <td>NOV 7, 2018</td>
+                </tr>
+                <tr>
+                  <td colspan="20">
+                    <list styleCode="none">
+                      <item>
+                        <table>
+                          <thead>
+                            <tr>
+                              <th>Problem Type</th>
+                              <th>Problem</th>
+                              <th>Date(s)</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr ID="id_ab1791b0-5c71-11db-b0de-0800200c9a66_ref">
+                              <td>Symptom</td>
+                              <td>Dark stools (finding)</td>
+                              <td>NOV 1, 2018</td>
+                            </tr>
+                            <tr ID="id_ab1791b0-5c71-11db-b0de-0800200c9a67_ref">
+                              <td>Complaint</td>
+                              <td>Paroxysmal cough (finding)</td>
+                              <td>NOV 4, 2018</td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </item>
+                    </list>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table>
+              <thead>
+                <tr>
+                  <th>Concern</th>
+                  <th>Concern Status</th>
+                  <th>Date(s)</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr ID="id_ec8a6ff8-ed4b-4f7e-82c3-e98e58b45de8_ref">
+                  <td>Problem</td>
+                  <td>active</td>
+                  <td>MAY 23, 2018</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <entry typeCode="DRIV">
+            <act classCode="ACT" moodCode="EVN">
+              <!-- [C-CDA 1.1] Problem Concern Act -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.3" />
+              <!-- [C-CDA 2.1] Problem Concern Act (V3) -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01" />
+              <id root="ec8a6ff8-ed4b-4f7e-82c3-e98e58b45de7" />
+              <code code="CONC" codeSystem="2.16.840.1.113883.5.6" displayName="Concern" />
+              <!-- The statusCode represents the need to continue tracking the problem -->
+              <!-- This is of ongoing concern to the provider -->
+              <statusCode code="active" />
+              <effectiveTime>
+                <!-- The low value represents when the problem was first recorded in the patient's chart -->
+                <low value="20181107" />
+              </effectiveTime>
+              <entryRelationship typeCode="SUBJ">
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [C-CDA R1.1] Problem Observation -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                  <!-- [C-CDA R2.1] Problem Observation (V3) -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+                  <id root="ab1791b0-5c71-11db-b0de-0800200c9a66" />
+                  <code code="75325-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Symptom">
+                    <translation code="418799008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Symptom" />
+                  </code>
+                  <!-- The statusCode reflects the status of the observation itself -->
+                  <statusCode code="completed" />
+                  <effectiveTime>
+                    <!-- The low value reflects the date of onset -->
+                    <low value="20181101" />
+                  </effectiveTime>
+                  <value code="35064005" codeSystem="2.16.840.1.113883.6.96" displayName="Dark stools (finding)" xsi:type="CD" />
+                </observation>
+              </entryRelationship>
+              <entryRelationship typeCode="SUBJ">
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [C-CDA R1.1] Problem Observation -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                  <!-- [C-CDA R2.1] Problem Observation (V3) -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+                  <id root="ab1791b0-5c71-11db-b0de-0800200c9a67" />
+                  <code code="75322-8" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Complaint">
+                    <translation code="409586006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Complaint" />
+                  </code>
+                  <!-- The statusCode reflects the status of the observation itself -->
+                  <statusCode code="completed" />
+                  <effectiveTime>
+                    <!-- The low value reflects the date of onset -->
+                    <low value="20181104" />
+                  </effectiveTime>
+                  <value code="43025008" codeSystem="2.16.840.1.113883.6.96" displayName="Paroxysmal cough (finding)" xsi:type="CD" />
+                </observation>
+              </entryRelationship>
+            </act>
+          </entry>
+          <entry typeCode="DRIV">
+            <act classCode="ACT" moodCode="EVN">
+              <!-- [C-CDA 1.1] Problem Concern Act -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.3" />
+              <!-- [C-CDA 2.1] Problem Concern Act (V3) -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01" />
+              <id root="ec8a6ff8-ed4b-4f7e-82c3-e98e58b45de8" />
+              <code code="CONC" codeSystem="2.16.840.1.113883.5.6" displayName="Concern" />
+              <!-- The statusCode represents the need to continue tracking the problem -->
+              <!-- This is of ongoing concern to the provider -->
+              <statusCode code="active" />
+              <effectiveTime>
+                <!-- The low value represents when the problem was first recorded in the patient's chart -->
+                <low value="20180523" />
+              </effectiveTime>
+              <entryRelationship typeCode="SUBJ">
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [C-CDA R1.1] Problem Observation -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                  <!-- [C-CDA R2.1] Problem Observation (V3) -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+                  <id root="ab1791b0-5c71-11db-b0de-0800200c9a66" />
+                  <code code="75325-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Symptom">
+                    <translation code="418799008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Symptom" />
+                  </code>
+                  <!-- The statusCode reflects the status of the observation itself -->
+                  <statusCode code="completed" />
+                  <effectiveTime>
+                    <!-- The low value reflects the date of onset -->
+                    <low value="20181101" />
+                  </effectiveTime>
+                  <value code="35064005" codeSystem="2.16.840.1.113883.6.96" displayName="Dark stools (finding)" xsi:type="CD" />
+                </observation>
+              </entryRelationship>
+              <entryRelationship typeCode="SUBJ">
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [C-CDA R1.1] Problem Observation -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                  <!-- [C-CDA R2.1] Problem Observation (V3) -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+                  <id root="ab1791b0-5c71-11db-b0de-0800200c9a67" />
+                  <code code="75322-8" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Complaint">
+                    <translation code="409586006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Complaint" />
+                  </code>
+                  <!-- The statusCode reflects the status of the observation itself -->
+                  <statusCode code="completed" />
+                  <effectiveTime>
+                    <!-- The low value reflects the date of onset -->
+                    <low value="20181104" />
+                  </effectiveTime>
+                  <value code="43025008" codeSystem="2.16.840.1.113883.6.96" displayName="Paroxysmal cough (finding)" xsi:type="CD" />
+                </observation>
+              </entryRelationship>
+            </act>
+          </entry>
+        </section>
+      </component>
+      <!--
+         ********************************************************
+         Reason for Visit Section
+         ********************************************************
+      -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.12" />
+          <code code="29299-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Reason for visit" />
+          <title>Reason for Visit</title>
+          <text>
+            <paragraph>Dark stools</paragraph>
+          </text>
+        </section>
+      </component>
+      <!--
+          ********************************************************
+          Results Section (entries required) (V3)
+          ********************************************************
+      -->
+      <component>
+        <section>
+          <!-- [C-CDA R1.1] Results Section (entries optional) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.3" />
+          <!-- [C-CDA R2.1] Results Section (entries optional) (V3) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.3" extension="2015-08-01" />
+          <!-- [C-CDA R1.1] Results Section (entries required) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.3.1" />
+          <!-- [C-CDA R2.1] Results Section (entries required) (V3) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.3.1" extension="2015-08-01" />
+          <code code="30954-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Relevant diagnostic tests and/or laboratory data" />
+          <title>Results</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Results Panel</th>
+                  <th>Date(s)</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr ID="id_7d5a02b0-67a4-11db-bd13-0800200c9a66_ref">
+                  <td>CBC W Auto Differential panel in Blood</td>
+                  <td>NOV 7, 2018 to NOV 7, 2018</td>
+                </tr>
+                <tr>
+                  <td colspan="20">
+                    <list styleCode="none">
+                      <item>
+                        <table>
+                          <thead>
+                            <tr>
+                              <th>Test</th>
+                              <th>Outcome</th>
+                              <th>Interpretation</th>
+                              <th>Date(s)</th>
+                              <th>Reference Range</th>
+                              <th>Reference Range Interpretation</th>
+                              <th>Reference Range Description</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr ID="id_7c0704bb-9c40-41b5-9c7d-26b2d59e234f_ref">
+                              <td>Hematocrit</td>
+                              <td>35.3 %</td>
+                              <td>Low</td>
+                              <td>NOV 7, 2018</td>
+                              <td>34.9 % to 44.5 %</td>
+                              <td>Low</td>
+                              <td>Low</td>
+                            </tr>
+                            <tr ID="id_7c0704bb-9c40-41b5-9c7d-26b2d59e234g_ref">
+                              <td>Lymphocytes [#/​volume] in Blood by Automated count</td>
+                              <td>5.2 10*3/uL</td>
+                              <td>High</td>
+                              <td>NOV 7, 2018</td>
+                              <td>1.0 10*3/uL to 4.8 10*3/uL</td>
+                              <td>Normal</td>
+                              <td />
+                            </tr>
+                          </tbody>
+                        </table>
+                      </item>
+                    </list>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table>
+              <thead>
+                <tr>
+                  <th>Results Panel</th>
+                  <th>Date(s)</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr ID="id_a4307cb2-b3b4-4f42-be03-1d9077376f4a_ref">
+                  <td>Bordetella pertussis Ab<br />[Units/volume] in Serum</td>
+                  <td>NOV 7, 2018 to NOV 7, 2018</td>
+                </tr>
+                <tr>
+                  <td colspan="20">
+                    <list styleCode="none">
+                      <item>
+                        <table>
+                          <thead>
+                            <tr>
+                              <th>Initial Case Report Trigger<br />Code Result Observation </th>
+                              <th>Trigger Code</th>
+                              <th>Trigger Code codeSystem</th>
+                              <th>RCTC OID</th>
+                              <th>RCTC Version</th>
+                              <th>Outcome</th>
+                              <th>Interpretation</th>
+                              <th>Date(s)</th>
+                              <th>Reference Range</th>
+                              <th>Reference Range Interpretation</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr ID="id_bf9c0a26-4524-4395-b3ce-100450b9c9ad_ref">
+                              <td>Bordetella pertussis Ab<br />[Units/volume] in Serum</td>
+                              <td>11585-7</td>
+                              <td>LOINC</td>
+                              <td>2.16.840.1.114222.4.11.7508</td>
+                              <td>19/05/2018</td>
+                              <td>100 [iU]/mL</td>
+                              <td>High</td>
+                              <td>NOV 7, 2018</td>
+                              <td> to 45 [iU]/mL</td>
+                              <td>Normal</td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </item>
+                    </list>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table>
+              <thead>
+                <tr>
+                  <th>Results Panel</th>
+                  <th>Date(s)</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr ID="id_a4307cb2-b3b4-4f42-be03-1d9077376f4b_ref">
+                  <td>Bordetella pertussis [Presence]<br />in Throat by Organism specific culture</td>
+                  <td>NOV 7, 2018 to NOV 7, 2018</td>
+                </tr>
+                <tr>
+                  <td colspan="20">
+                    <list styleCode="none">
+                      <item>
+                        <table>
+                          <thead>
+                            <tr>
+                              <th>Initial Case Report Trigger Code Result Observation </th>
+                              <th>Trigger Code</th>
+                              <th>Trigger Code codeSystem</th>
+                              <th>RCTC OID</th>
+                              <th>RCTC Version</th>
+                              <th>Outcome</th>
+                              <th>Trigger Code</th>
+                              <th>Trigger Code codeSystem</th>
+                              <th>RCTC OID</th>
+                              <th>RCTC Version</th>
+                              <th>Interpretation</th>
+                              <th>Date(s)</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr ID="id_bf9c0a26-4524-4395-b3ce-100450b9c9ac_ref">
+                              <td>Bordetella pertussis [Presence]<br />in Throat by Organism specific culture</td>
+                              <td>548-8</td>
+                              <td>LOINC</td>
+                              <td>2.16.840.1.114222.4.11.7508</td>
+                              <td>19/05/2018</td>
+                              <td>Bordetella pertussis (organism)</td>
+                              <td>5247005</td>
+                              <td>SNOMED CT</td>
+                              <td>2.16.840.1.114222.4.11.7508</td>
+                              <td>19/05/2018</td>
+                              <td>Abnormal</td>
+                              <td>NOV 7, 2018</td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </item>
+                    </list>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <entry typeCode="DRIV">
+            <organizer classCode="BATTERY" moodCode="EVN">
+              <!-- [C-CDA R1.1] Result Organizer -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.1" />
+              <!-- [C-CDA R2.1] Result Organizer (V3) -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2015-08-01" />
+              <!-- [eICR R2 STU2] Initial Case Report Trigger Code Result Organizer -->
+              <templateId root="2.16.840.1.113883.10.20.15.2.3.35" extension="2019-04-01" />
+              <id root="7d5a02b0-67a4-11db-bd13-0800200c9a66" />
+              <code displayName="CBC W Auto Differential panel in Blood" code="57021-8" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                sdtc:valueSet="2.16.840.1.114222.4.11.7508" sdtc:valueSetVersion="12/12/2018" />
+              <statusCode code="completed" />
+              <effectiveTime>
+                <low value="20181107" />
+                <high value="20181107" />
+              </effectiveTime>
+              <component>
+                <!-- This observation is a non-trigger code result observation -->
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [C-CDA R1.1] Result Observation -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                  <!-- [C-CDA R2.1] Result Observation (V3) -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2" extension="2015-08-01" />
+                  <id root="7c0704bb-9c40-41b5-9c7d-26b2d59e234f" />
+                  <code code="20570-8" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Hematocrit" />
+                  <statusCode code="completed" />
+                  <effectiveTime value="20181107" />
+                  <value unit="%" value="35.3" xsi:type="PQ" />
+                  <interpretationCode code="L" codeSystem="2.16.840.1.113883.5.83" displayName="Low" />
+                  <referenceRange>
+                    <observationRange>
+                      <text>Low</text>
+                      <value xsi:type="IVL_PQ">
+                        <low unit="%" value="34.9" />
+                        <high unit="%" value="44.5" />
+                      </value>
+                      <interpretationCode code="L" codeSystem="2.16.840.1.113883.5.83" displayName="Low" />
+                    </observationRange>
+                  </referenceRange>
+                </observation>
+              </component>
+              <component>
+                <!-- This observation is a non-trigger code result observation -->
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [C-CDA R1.1] Result Observation -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                  <!-- [C-CDA R2.1] Result Observation (V3) -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2" extension="2015-08-01" />
+                  <id root="7c0704bb-9c40-41b5-9c7d-26b2d59e234g" />
+                  <code code="731-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Lymphocytes [#/​volume] in Blood by Automated count" />
+                  <statusCode code="completed" />
+                  <effectiveTime value="20181107" />
+                  <value unit="10*3/uL" value="5.2" xsi:type="PQ" />
+                  <interpretationCode code="H" codeSystem="2.16.840.1.113883.5.83" displayName="High" />
+                  <referenceRange>
+                    <observationRange>
+                      <value xsi:type="IVL_PQ">
+                        <low unit="10*3/uL" value="1.0" />
+                        <high unit="10*3/uL" value="4.8" />
+                      </value>
+                      <interpretationCode code="N" codeSystem="2.16.840.1.113883.5.83" displayName="Normal" />
+                    </observationRange>
+                  </referenceRange>
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [C-CDA ID] Laboratory Result Status (ID) -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.418" extension="2018-09-01" />
+                  <code code="92235-1" displayName="Laboratory Result Status" codeSystemName="LOINC" codeSystem="2.16.840.1.113883.6.1" />
+                  <value xsi:type="CE" code="F" displayName="Final results; results stored and verified. Can only be changed with a corrected result."
+                    codeSystem="2.16.840.1.113883.18.51" codeSystemName="HL7ResultStatus" />
+                </observation>
+              </component>
+              <component>
+                <procedure classCode="PROC" moodCode="EVN">
+                  <!-- [C-CDA] Specimen Collection Procedure (ID) -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.315" extension="2018-09-01" />
+                  <code code="17636008" displayName="Specimen collection (procedure)" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+                  <!-- Specimen collection date/time -->
+                  <effectiveTime>
+                    <low value="20180309" />
+                  </effectiveTime>
+                  <!-- Specimen source -->
+                  <targetSiteCode code="368208006" displayName="Left upper arm structure (body structure)" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+                  <!-- [C-CDA ID]  Specimen Participant (ID) -->
+                  <participant typeCode="PRD">
+                    <!-- [C-CDA ID] Specimen Participant (ID) -->
+                    <templateId root="2.16.840.1.113883.10.20.22.4.310" extension="2018-09-01" />
+                    <participantRole classCode="SPEC">
+                      <!-- Specimen id -->
+                      <id root="44fd0410-6115-4b8e-8ee9-a51b3817df66" />
+                      <playingEntity>
+                        <!-- Specimen type -->
+                        <code code="119297000" displayName="Blood specimen (specimen)" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+                      </playingEntity>
+                    </participantRole>
+                  </participant>
+                </procedure>
+              </component>
+            </organizer>
+          </entry>
+          <entry typeCode="DRIV">
+            <organizer classCode="BATTERY" moodCode="EVN">
+              <!-- [C-CDA R1.1] Result Organizer -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.1" />
+              <!-- [C-CDA R2.1] Result Organizer (V3) -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2015-08-01" />
+              <id root="a4307cb2-b3b4-4f42-be03-1d9077376f4a" />
+              <code code="11585-7" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Bordetella pertussis Ab [Units/volume] in Serum" />
+              <!-- statusCode must be set to completed because the statusCode of the observation is completed -->
+              <statusCode code="completed" />
+              <effectiveTime>
+                <low value="20181107" />
+                <high value="20181107" />
+              </effectiveTime>
+              <component>
+                <!-- This observation is a trigger code final result observation -
+                   only the code is a trigger code and thus
+                   only the code must contain @sdtc:valueSet and @sdtc:valueSetVersion.
+                   Final result is indicated by statusCode="final" along with the corresponding
+                   value (F) in the Laboratory Observation Result Status (ID) template -->
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [C-CDA R1.1] Result Observation -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                  <!-- [C-CDA R2.1] Result Observation (V3) -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2" extension="2015-08-01" />
+                  <!-- [eICR R2 STU2] Initial Case Report Trigger Code Result Observation (V2) -->
+                  <templateId root="2.16.840.1.113883.10.20.15.2.3.2" extension="2019-04-01" />
+                  <id root="bf9c0a26-4524-4395-b3ce-100450b9c9ad" />
+                  <!-- This code is a trigger code from RCTC subset:
+                       "R4 Lab Obs Test Name Triggers for Public Health Reporting (RCTC subset)"
+                       @sdtc:valueSet and @sdtc:valueSetVersion shall be present -->
+                  <code code="11585-7" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Bordetella pertussis Ab [Units/volume] in Serum"
+                    sdtc:valueSet="2.16.840.1.114222.4.11.7508" sdtc:valueSetVersion="12/12/2018" />
+                  <!-- statusCode is set to completed indicating that this is a final result -->
+                  <statusCode code="completed" />
+                  <effectiveTime value="20181107" />
+                  <!-- It is not necessary that the result value (contained in value) is a coded value
+                    (though, in order for a result value to be a trigger, it must be coded),
+                    but if codes are available they **SHALL** be used. -->
+                  <!-- This value is a physical quantity and thus cannot be a trigger code -->
+                  <value xsi:type="PQ" unit="[iU]/mL" value="100" />
+                  <!-- This interpretation code denotes that this patient value is above high normal -->
+                  <interpretationCode code="H" displayName="High" codeSystem="2.16.840.1.113883.5.83" codeSystemName="ObservationInterpretation" />
+                  <!-- Laboratory Observation Result Status (ID) -->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!-- [C-CDA ID] Laboratory Observation Result Status (ID) -->
+                      <templateId root="2.16.840.1.113883.10.20.22.4.419" extension="2018-09-01" />
+                      <code code="92236-9" displayName="Laboratory Observation Result Status" codeSystemName="LOINC" codeSystem="2.16.840.1.113883.6.1" />
+                      <value xsi:type="CD" code="F" displayName="Final results" codeSystem="2.16.840.1.113883.18.34"
+                        codeSystemName="HL7ObservationResultStatusCodesInterpretation" />
+                    </observation>
+                  </entryRelationship>
+                  <referenceRange>
+                    <observationRange>
+                      <!-- Reference range: PT IgG: <45 IU/mL -->
+                      <value xsi:type="IVL_PQ">
+                        <high inclusive="false" unit="[iU]/mL" value="45" />
+                      </value>
+                      <!-- This interpretation code denotes that this reference range is for normal results.
+                           This is not the interpretation of a specific patient value-->
+                      <interpretationCode code="N" codeSystem="2.16.840.1.113883.5.83" displayName="Normal" />
+                    </observationRange>
+                  </referenceRange>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+          <entry typeCode="DRIV">
+            <organizer classCode="BATTERY" moodCode="EVN">
+              <!-- [C-CDA R1.1] Result Organizer -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.1" />
+              <!-- [C-CDA R2.1] Result Organizer (V3) -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2015-08-01" />
+              <id root="a4307cb2-b3b4-4f42-be03-1d9077376f4b" />
+              <code code="548-8" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                displayName="Bordetella pertussis [Presence] in Throat by Organism specific culture" />
+              <!-- statusCode must be set to active because the statusCode of the observation is active -->
+              <statusCode code="active" />
+              <effectiveTime>
+                <low value="20181107" />
+                <high value="20181107" />
+              </effectiveTime>
+              <component>
+                <!-- This observation is a trigger code preliminary result observation -
+                     both the code and value are trigger codes and thus
+                     both the code and the value must contain @sdtc:valueSet and @sdtc:valueSetVersion.
+                     Preliminary result is indicated by statusCode="active"
+                     along with the corresponding value (P) in the Laboratory Observation Result Status (ID) template -->
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [C-CDA R1.1] Result Observation -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                  <!-- [C-CDA R2.1] Result Observation (V3) -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2" extension="2015-08-01" />
+                  <!-- [eICR R2 STU2] Initial Case Report Trigger Code Result Observation (V2) -->
+                  <templateId root="2.16.840.1.113883.10.20.15.2.3.2" extension="2019-04-01" />
+                  <id root="bf9c0a26-4524-4395-b3ce-100450b9c9ac" />
+                  <!-- This code is a trigger code from RCTC subset:
+                       "R4 Lab Obs Test Name Triggers for Public Health Reporting (RCTC subset)"
+                       @sdtc:valueSet and @sdtc:valueSetVersion shall be present -->
+                  <!-- Example (fake) of the trigger code contained in the translation element -->
+                  <code code="local_code_pertussis" codeSystem="2.16.840.1.113883.1.2.3.665" codeSystemName="local_coding_system"
+                    displayName="Bordetella pertussis in Throat by Organism specific culture">
+                    <!-- Example of the trigger code contained in the translation element -->
+                    <translation code="548-8" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                      displayName="Bordetella pertussis [Presence] in Throat by Organism specific culture" sdtc:valueSet="2.16.840.1.114222.4.11.7508"
+                      sdtc:valueSetVersion="12/12/2018" />
+                  </code>
+                  <!-- statusCode is set to active indicating that this is a preliminary result -->
+                  <statusCode code="active" />
+                  <effectiveTime value="20181107" />
+                  <!-- This value is a trigger code from RCTC subset:
+                       "R4 Organism_Substance Triggers for Public Health Reporting (RCTC subset)"
+                       @sdtc:valueSet and @sdtc:valueSetVersion shall be present -->
+                  <!-- It is not necessary that the result value (contained in value) is a coded value
+                    (though, in order for a result value to be a trigger, it must be coded),
+                    but if codes are available they **SHALL** be used. -->
+                  <!-- This value is a physical quantity and thus cannot be a trigger code -->
+                  <value xsi:type="CD" code="5247005" displayName="Bordetella pertussis (organism)" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                    sdtc:valueSet="2.16.840.1.114222.4.11.7508" sdtc:valueSetVersion="12/12/2018" />
+                  <!-- This interpretation code denotes that this patient value is abnormal
+                       (bordetella pertussis (organism) was present in the culture) -->
+                  <interpretationCode code="A" displayName="Abnormal" codeSystem="2.16.840.1.113883.5.83" codeSystemName="ObservationInterpretation" />
+                  <!-- Laboratory Observation Result Status (ID) -->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!-- [C-CDA ID] Laboratory Observation Result Status (ID) -->
+                      <templateId root="2.16.840.1.113883.10.20.22.4.419" extension="2018-09-01" />
+                      <code code="92236-9" displayName="Laboratory Observation Result Status" codeSystemName="LOINC" codeSystem="2.16.840.1.113883.6.1" />
+                      <value xsi:type="CD" code="P" displayName="Preliminary results" codeSystem="2.16.840.1.113883.18.34"
+                        codeSystemName="HL7ObservationResultStatusCodesInterpretation" />
+                    </observation>
+                  </entryRelationship>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+      <!--
+          ********************************************************
+          Immunizations Section (entries required)(V3)
+          ********************************************************
+      -->
+      <component>
+        <section>
+          <!-- [C-CDA R2.1] Immunizations Section (entries required)(V3) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.2.1" extension="2015-08-01" />
+          <code code="11369-6" displayName="Hx of Immunization" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+          <title>Immunizations</title>
+          <text>
+            <table>
+
+              <thead>
+                <tr>
+                  <th>Immunization</th>
+                  <th>Immunization Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>diphtheria, tetanus toxoids and acellular<br />pertussis vaccine, 5 pertussis antigens</td>
+                  <td>NOV 11, 2018</td>
+                </tr>
+              </tbody>
+            </table>
+            <table>
+
+              <thead>
+                <tr>
+                  <th>Initial Case Report Trigger Code<br />Immunization Medication Activity</th>
+                  <th>Immunization Date</th>
+                  <th>Trigger<br />Code</th>
+                  <th>Trigger Code<br />codeSystem</th>
+                  <th>RCTC OID</th>
+                  <th>RCTC<br />Version</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>influenza virus vaccine, unspecified formulation</td>
+                  <td>NOV 11, 2018</td>
+                  <td>88</td>
+                  <td>CVX</td>
+                  <td>2.16.840.1.114222.4.11.7508</td>
+                  <td>19/05/2018</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <entry>
+            <!-- Non trigger code vaccine -->
+            <substanceAdministration classCode="SBADM" moodCode="EVN" negationInd="false">
+              <!-- [C-CDA 2.1] Immunization Activity (V3) -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.52" extension="2015-08-01" />
+              <id root="00000000-5CF3-EC63-0513-4A4838595787" extension="11369-6_3-1_1.3.6.1.4.1.22812.11.2016.163.1_14168" />
+              <statusCode code="completed" />
+              <effectiveTime value="20181107" />
+              <routeCode nullFlavor="NI" />
+              <doseQuantity nullFlavor="NI" />
+              <consumable>
+                <manufacturedProduct classCode="MANU">
+                  <!-- [C-CDA R2.1] Immunization Medication Information (V3) -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.54" extension="2014-06-09" />
+                  <manufacturedMaterial>
+                    <code code="106" codeSystem="2.16.840.1.113883.12.292" displayName="diphtheria, tetanus toxoids and acellular pertussis vaccine, 5 pertussis antigens" />
+                    <lotNumberText nullFlavor="NI" />
+                  </manufacturedMaterial>
+                </manufacturedProduct>
+              </consumable>
+            </substanceAdministration>
+          </entry>
+          <entry>
+            <!-- Example of a trigger code vaccine
+                 NOTE: at the time of writing there were no published immunization trigger codes
+                       so this is a synthetic example -->
+            <substanceAdministration classCode="SBADM" moodCode="EVN" negationInd="false">
+              <!-- [C-CDA 2.1] Immunization Activity (V3) -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.52" extension="2015-08-01" />
+              <id root="00000000-5CF3-EC63-0513-4A4838595787" extension="11369-6_2-1_1.3.6.1.4.1.22812.11.2016.163.1_14168" />
+              <statusCode code="completed" />
+              <effectiveTime value="20181107" />
+              <routeCode nullFlavor="NI" />
+              <doseQuantity nullFlavor="NI" />
+              <consumable>
+                <manufacturedProduct classCode="MANU">
+                  <!-- [C-CDA R2.1] Immunization Medication Information (V3) -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.54" extension="2014-06-09" />
+                  <!-- [eICR R2 STU2] Initial Case Report Trigger Code Problem Observation (V2) -->
+                  <templateId root="2.16.840.1.113883.10.20.15.2.3.38" extension="2019-04-01" />
+                  <!-- Trigger code -->
+                  <manufacturedMaterial>
+                    <code code="88" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="influenza virus vaccine, unspecified formulation"
+                      sdtc:valueSet="2.16.840.1.114222.4.11.7508" sdtc:valueSetVersion="12/12/2018" />
+                    <lotNumberText nullFlavor="NI" />
+                  </manufacturedMaterial>
+                </manufacturedProduct>
+              </consumable>
+            </substanceAdministration>
+          </entry>
+        </section>
+      </component>
+
+      <!--
+          ********************************************************
+          Social History Section (V3)
+          ********************************************************
+      -->
+      <component>
+        <section>
+          <!-- [C-CDA 1.1] Social History Section -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.17" />
+          <!-- [C-CDA 2.1] Social History Section (V3) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.17" extension="2015-08-01" />
+          <code code="29762-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Social History" />
+          <title>Social History</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Birth Sex</th>
+                  <th>Value</th>
+                  <th>Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Sex Assigned At Birth</td>
+                  <td>Female</td>
+                  <td>NOV 24, 1974</td>
+                </tr>
+              </tbody>
+            </table>
+            <table>
+              <thead>
+                <tr>
+                  <th>Gender identity</th>
+                  <th>Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Female-to-male transsexual (finding)</td>
+                  <td>JAN 1, 2018</td>
+                </tr>
+              </tbody>
+            </table>
+            <table>
+              <thead>
+                <tr>
+                  <th>Characteristics of Home Environment</th>
+                  <th>Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Homeless</td>
+                  <td>NOV 9, 2018</td>
+                </tr>
+              </tbody>
+            </table>
+            <table>
+              <thead>
+                <tr>
+                  <th>Current Occupation</th>
+                  <th>Current Industry</th>
+                  <th>Current Job Title</th>
+                  <th>Current Employer</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Actuaries</td>
+                  <td>Accounting, tax preparation, bookkeeping, and payroll services</td>
+                  <td>Senior Accountant</td>
+                  <td>CDC, Peachtree St, Ann Arbor Georgia, 555-1212</td>
+                </tr>
+              </tbody>
+            </table>
+            <table>
+              <thead>
+                <tr>
+                  <th>Usual Occupation</th>
+                  <th>Usual Industry</th>
+                  <th>Occupational Exposure</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Actuaries</td>
+                  <td>Accounting, tax preparation, bookkeeping, and payroll services</td>
+                  <td>Asbestos</td>
+                </tr>
+              </tbody>
+            </table>
+            <table>
+              <thead>
+                <tr>
+                  <th>Travel History: Date(s)</th>
+                  <th>Notes</th>
+                  <th>Location</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>1999 to 2007</td>
+                  <td>Spent 8 years in the UK during the BSE outbreak</td>
+                  <td />
+                </tr>
+                <tr>
+                  <td>In the 3 weeks before NOV 9, 2018</td>
+                  <td />
+                  <td>
+                    <list styleCode="none">
+                      <item>Brazil</item>
+                    </list>
+                  </td>
+                </tr>
+                <tr>
+                  <td>APR 25, 2018 to APR 30, 2018</td>
+                  <td />
+                  <td>
+                    <list styleCode="none">
+                      <item>Nadi, FJ</item>
+                    </list>
+                  </td>
+                </tr>
+                <tr>
+                  <td>MAY 6, 2018 to MAY 15, 2018</td>
+                  <td />
+                  <td>
+                    <list styleCode="none">
+                      <item>Montreal, QC, CA</item>
+                    </list>
+                  </td>
+                </tr>
+                <tr>
+                  <td>JUL 13, 2018 to JUL 15, 2018</td>
+                  <td />
+                  <td>
+                    <list styleCode="none">
+                      <item>Sydney, NSW, AU</item>
+                    </list>
+                  </td>
+                </tr>
+                <tr>
+                  <td>OCT 22, 2018 to OCT 30, 2018</td>
+                  <td />
+                  <td>
+                    <list styleCode="none">
+                      <item>1170 N Rancho Robles Rd Oracle, AZ8562, US</item>
+                    </list>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <entry typeCode="DRIV">
+            <observation classCode="OBS" moodCode="EVN">
+              <!-- [C-CDA R2.1 Companion Guide] Birth Sex Observation -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.200" extension="2016-06-01" />
+              <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" displayName="Sex Assigned At Birth" />
+              <statusCode code="completed" />
+              <!-- effectiveTime if present should match birthTime -->
+              <effectiveTime value="19741124" />
+              <value xsi:type="CD" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGender" code="F" displayName="Female"> </value>
+            </observation>
+          </entry>
+          <entry>
+            <!-- Gender Identity Observation-->
+            <observation classCode="OBS" moodCode="EVN">
+              <!-- [NHCS R1D3] Gender Identity Observation -->
+              <templateId root="2.16.840.1.113883.10.20.34.3.45" extension="2019-04-01" />
+              <id root="5501b49a-32ea-4c78-9c31-3dbe782871b7" />
+              <code code="76691-5" displayName="Gender identity" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+              <statusCode code="completed" />
+              <effectiveTime value="20180101" />
+              <value xsi:type="CD" code="407377005" displayName="Female-to-male transsexual (finding)" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+            </observation>
+          </entry>
+          <entry>
+            <!-- Patient is homeless -->
+            <observation classCode="OBS" moodCode="EVN">
+              <!-- [C-CDA R2] Characteristics of Home Environment -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.109" />
+              <id root="37f76c51-6411-4e1d-8a37-957fd49d2ced" />
+              <code code="75274-1" codeSystem="2.16.840.1.113883.6.1" displayName="Characteristics of residence" />
+              <statusCode code="completed" />
+              <effectiveTime value="20181109" />
+              <value xsi:type="CD" code="32911000" displayName="Homeless (finding)" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+            </observation>
+          </entry>
+          <entry typeCode="DRIV">
+            <!-- Travel History - text example - no specific location -->
+            <act classCode="ACT" moodCode="EVN">
+              <!-- [eICR R2 STU1.1] Travel History -->
+              <templateId root="2.16.840.1.113883.10.20.15.2.3.1" extension="2016-12-01" />
+              <id root="79565142-eae0-4213-a3b3-b73cdf474682" />
+              <code code="420008001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Travel" />
+              <text>Spent 8 years in the UK during the BSE outbreak</text>
+              <statusCode code="completed" />
+              <!-- Duration (from 1999 to 2007) -->
+              <effectiveTime>
+                <low value="1999" />
+                <high value="2007" />
+              </effectiveTime>
+            </act>
+          </entry>
+          <entry typeCode="DRIV">
+            <!-- Travel History - participant with coded location -->
+            <act classCode="ACT" moodCode="EVN">
+              <!-- [eICR R2 STU1.1] Travel History -->
+              <templateId root="2.16.840.1.113883.10.20.15.2.3.1" extension="2016-12-01" />
+              <id root="030df1dc-1d31-4e5d-abdd-5edd0b74c5c3" />
+              <code code="420008001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Travel" />
+              <statusCode code="completed" />
+              <!-- Denotes "past 3 weeks" with the high value being the date the statement was made -->
+              <effectiveTime>
+                <width value="3" unit="weeks" />
+                <high value="20181109" />
+              </effectiveTime>
+              <participant typeCode="LOC">
+                <participantRole classCode="TERR">
+                  <!-- Code specifiying the location traveled -->
+                  <code code="BRA" displayName="Brazil" codeSystem="1.0.3166.1" codeSystemName="Country (ISO 3166-1)" />
+                </participantRole>
+              </participant>
+            </act>
+          </entry>
+          <entry typeCode="DRIV">
+            <!-- Travel History - participant location with address specific to city -->
+            <act classCode="ACT" moodCode="EVN">
+              <!-- [eICR R2 STU1.1] Travel History -->
+              <templateId root="2.16.840.1.113883.10.20.15.2.3.1" extension="2016-12-01" />
+              <id root="b98e410c-d29a-46d8-8fc8-f55a9d3022b9" />
+              <code code="420008001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Travel" />
+              <statusCode code="completed" />
+              <!-- Duration -->
+              <effectiveTime>
+                <low value="20180425" />
+                <high value="20180430" />
+              </effectiveTime>
+              <participant typeCode="LOC">
+                <participantRole classCode="TERR">
+                  <!-- Address specific to city -->
+                  <addr>
+                    <country>FJ</country>
+                    <city>Nadi</city>
+                  </addr>
+                </participantRole>
+              </participant>
+            </act>
+          </entry>
+          <entry typeCode="DRIV">
+            <!-- Travel History - participant location with addr
+                         specific to city and state (province) -->
+            <act classCode="ACT" moodCode="EVN">
+              <!-- [eICR R2 STU1.1] Travel History -->
+              <templateId root="2.16.840.1.113883.10.20.15.2.3.1" extension="2016-12-01" />
+              <id root="b97346f7-8f9e-4c5b-97bb-df4f6e057fd4" />
+              <code code="420008001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Travel" />
+              <statusCode code="completed" />
+              <!-- Duration -->
+              <effectiveTime>
+                <low value="20180506" />
+                <high value="20180515" />
+              </effectiveTime>
+              <participant typeCode="LOC">
+                <participantRole classCode="TERR">
+                  <addr>
+                    <country>CA</country>
+                    <city>Montreal</city>
+                    <state>QC</state>
+                  </addr>
+                </participantRole>
+              </participant>
+            </act>
+          </entry>
+          <entry typeCode="DRIV">
+            <!-- Travel History - participant location with addr
+                 specific to city and state -->
+            <act classCode="ACT" moodCode="EVN">
+              <!-- [eICR R2 STU1.1] Travel History -->
+              <templateId root="2.16.840.1.113883.10.20.15.2.3.1" extension="2016-12-01" />
+              <id root="1d957c2a-6133-427d-a6cc-26f132773b86" />
+              <code code="420008001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Travel" />
+              <statusCode code="completed" />
+              <effectiveTime>
+                <low value="20180713" />
+                <high value="20180715" />
+              </effectiveTime>
+              <participant typeCode="LOC">
+                <participantRole classCode="TERR">
+                  <addr>
+                    <country>AU</country>
+                    <city>Sydney</city>
+                    <state>NSW</state>
+                  </addr>
+                </participantRole>
+              </participant>
+            </act>
+          </entry>
+          <entry typeCode="DRIV">
+            <!-- Travel History - participant location with addr
+                 specific to street address-->
+            <act classCode="ACT" moodCode="EVN">
+              <!-- [eICR R2 STU1.1] Travel History -->
+              <templateId root="2.16.840.1.113883.10.20.15.2.3.1" extension="2016-12-01" />
+              <id root="45397b5c-e974-4cf1-8b19-e1555bd55701" />
+              <code code="420008001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Travel" />
+              <statusCode code="completed" />
+              <effectiveTime>
+                <low value="20181022" />
+                <high value="20181030" />
+              </effectiveTime>
+              <participant typeCode="LOC">
+                <participantRole classCode="TERR">
+                  <addr>
+                    <streetAddressLine>1170 N Rancho Robles Rd</streetAddressLine>
+                    <city>Oracle</city>
+                    <state>AZ</state>
+                    <postalCode>8562</postalCode>
+                    <country>US</country>
+                  </addr>
+                </participantRole>
+              </participant>
+            </act>
+          </entry>
+          <!-- Usual Occupation Observation -->
+          <entry>
+            <observation classCode="OBS" moodCode="EVN">
+              <!-- [ODH R1] Usual Occupation Observation -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.221" extension="2017-11-30" />
+              <id root="4f4b3876-8570-41a0-b995-cf34f37c5cbf" />
+              <code code="21843-8" displayName="Usual Occupation" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+              <statusCode code="completed" />
+              <effectiveTime>
+                <low value="19961124" />
+              </effectiveTime>
+              <!-- eICR Data element: Usual occupation -->
+              <value xsi:type="CD" code="1200" displayName="Actuaries" codeSystem="2.16.840.1.114222.4.5.314" codeSystemName="Occupation CDC Census 2010" />
+              <!-- eICR Usual Industry Occupation -->
+              <entryRelationship typeCode="REFR">
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [ODH R1] Usual Industry Observation -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.219" extension="2017-11-30" />
+                  <id root="280af6dc-bef4-4216-beb4-25579add98d4" />
+                  <code code="21844-6" displayName="Usual Industry" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                  <statusCode code="completed" />
+                  <effectiveTime>
+                    <low value="19961124" />
+                  </effectiveTime>
+                  <!-- eICR Data element: Usual industry -->
+                  <value xsi:type="CD" code="7280" displayName="Accounting, tax preparation, bookkeeping, and payroll services" codeSystem="2.16.840.1.114222.4.5.315"
+                    codeSystemName="Industry CDC Census 2010" />
+                </observation>
+              </entryRelationship>
+            </observation>
+          </entry>
+          <!-- Past or Present Occupation Observation -->
+          <entry>
+            <observation classCode="OBS" moodCode="EVN">
+              <!-- [ODH R1] Past or Present Occupation Observation -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.217" extension="2017-11-30" />
+              <id root="1728123a-7b6c-418c-adc2-f78417caf62c" />
+              <code code="11341-5" displayName="History of Occupation" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+              <text>Senior Accountant</text>
+              <!-- statusCode=active indicates that this is the current occupation -->
+              <statusCode code="active" />
+              <!-- effectiveTime/high omitted as this is the current occupation -->
+              <effectiveTime>
+                <low value="20150424" />
+              </effectiveTime>
+              <!-- eICR Data element: Current occupation -->
+              <value xsi:type="CD" code="1200" displayName="Actuaries" codeSystem="2.16.840.1.114222.4.5.314" codeSystemName="Occupation CDC Census 2010" />
+              <participant typeCode="IND">
+                <participantRole classCode="ROL">
+                  <id root="58822180-ab0d-42e4-90c6-35336bf55654" extension="12345" />
+                  <!-- eICR Data element: Employer address -->
+                  <addr>
+                    <streetAddressLine>Peachtree St</streetAddressLine>
+                    <city>Ann Arbor</city>
+                    <state>Georgia</state>
+                  </addr>
+                  <!-- eICR Data element: Employer phone -->
+                  <telecom use="WP" value="555-1212" />
+                  <playingEntity>
+                    <!-- eICR Data element: Employer name -->
+                    <name>CDC</name>
+                  </playingEntity>
+                </participantRole>
+              </participant>
+              <!-- Occupational Hazard Observation -->
+              <entryRelationship typeCode="REFR">
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [ODH R1] Occupational Hazard Observation -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.215" extension="2017-11-30" />
+                  <id root="8cb3c421-473b-43ee-96cd-a8e3514f7dc7" />
+                  <code code="87729-0" displayName="History of Occupational hazard" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+                  <statusCode code="completed" />
+                  <!-- eICR Data element: Occupational exposure -->
+                  <value xsi:type="ST">Asbestos</value>
+                </observation>
+              </entryRelationship>
+              <!-- Past or Present Industry Occupation -->
+              <entryRelationship typeCode="REFR">
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [ODH R1] Past or Present Industry Observation -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.216" extension="2017-11-30" />
+                  <id root="2cbd83d6-5fd7-436e-99cd-3e1644aa8742" />
+                  <code code="86188-0" displayName="Occupation Industry" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+
+                  <statusCode code="completed" />
+                  <!-- eICR Data element: Current industry -->
+                  <value xsi:type="CD" code="7280" displayName="Accounting, tax preparation, bookkeeping, and payroll services" codeSystem="2.16.840.1.114222.4.5.315"
+                    codeSystemName="Industry CDC Census 2010" />
+                </observation>
+              </entryRelationship>
+            </observation>
+          </entry>
+        </section>
+      </component>
+      <!--
+          ********************************************************
+          Pregnancy Section
+          ********************************************************
+      -->
+      <component>
+        <section>
+          <!--  [C-CDA PREG] Pregnancy Section -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.80" extension="2018-04-01" />
+          <code code="90767-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Pregnancy summary Document" />
+          <title>Pregnancy Section</title>
+          <text xmlns:voc="http://www.lantanagroup.com/voc">
+            <table>
+              <thead>
+                <tr>
+                  <th>Pregnancy Status</th>
+                  <th>Date(s) over which status holds<br />(if no high date, status was<br />current at time of recording)</th>
+                  <th>Determination Method</th>
+                  <th>Determination Date</th>
+                  <th>Recorded Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Pregnant</td>
+                  <td>AUG 26, 2017</td>
+                  <td>Diagnostic ultrasonography</td>
+                  <td>OCT 1, 2017</td>
+                  <td>OCT 1, 2017 10:35</td>
+                </tr>
+                <tr>
+                  <td colspan="20">
+                    <list styleCode="none">
+                      <item>
+                        <table>
+                          <thead>
+                            <tr>
+                              <th>Estimated Date of Delivery</th>
+                              <th>EDD</th>
+                              <th>EDD Determination Date</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr>
+                              <td>Delivery date estimated from ovulation date</td>
+                              <td>MAY 22, 2017</td>
+                              <td>OCT 1, 2017 10:15</td>
+                            </tr>
+                          </tbody>
+                        </table>
+                        <table>
+                          <thead>
+                            <tr>
+                              <th>Estimated Gestational Age of Pregnancy</th>
+                              <th>Days</th>
+                              <th>Determination Date</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr>
+                              <td>Gestational age Estimated from selected delivery date</td>
+                              <td>143 d</td>
+                              <td>OCT 1, 2017 10:15</td>
+                            </tr>
+                            <tr>
+                              <td colspan="20">
+                                <list styleCode="none">
+                                  <item>
+                                    <table>
+                                      <thead>
+                                        <tr>
+                                          <th>Reference to selected delivery date</th>
+                                        </tr>
+                                      </thead>
+                                      <tbody>
+                                        <tr>
+                                          <td>
+                                            <linkHtml href="#id_f3dfc576-2329-4f71-af3f-d500cab1146b_ref">Link to referenced entry</linkHtml>
+                                          </td>
+                                        </tr>
+                                      </tbody>
+                                    </table>
+                                  </item>
+                                </list>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                        <table>
+                          <thead>
+                            <tr>
+                              <th>Pregnancy Outcome</th>
+                              <th>Birth Order</th>
+                              <th>Time</th>
+                              <th>Method of Delivery</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr>
+                              <td>Stillbirth (finding)</td>
+                              <td>1</td>
+                              <td>JAN 5, 2018 08:50</td>
+                              <td>Breech delivery (procedure)</td>
+                            </tr>
+                            <tr>
+                              <td>Term birth of newborn (finding)</td>
+                              <td>2</td>
+                              <td>JAN 5, 2018 10:05</td>
+                              <td>Breech delivery (procedure)</td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </item>
+                    </list>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table>
+              <thead>
+                <tr>
+                  <th>Last menstrual period start date</th>
+                  <th>Observation Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>AUG 1, 2017</td>
+                  <td>JAN 5, 2018 10:15</td>
+                </tr>
+              </tbody>
+            </table>
+            <table>
+              <thead>
+                <tr>
+                  <th>Postpartum Status</th>
+                  <th>Observation date</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Mid postpartum state (finding)</td>
+                  <td>JAN 5, 2018 10:15</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+
+          <!-- Pregnancy Observation (SUPPLEMENTAL PREGNANCY) -->
+          <entry typeCode="DRIV">
+            <!-- To assert a pregnancy status of:
+                     * pregnant: set value to 77386006 |Pregnant (finding)
+                     * possibly pregnant: set value to 102874004 |Possible pregnancy (finding)
+                     * not pregnant: set value to 60001007 |Not pregnant (finding)
+                     * unknown: set nullFlavor="UNK" and value/@nullFlavor to "UNK"
+                 Use the effectiveTime to indicate the date range over which the patient was pregnant/possibly pregnant/not pregnant/unknown. -->
+            <observation classCode="OBS" moodCode="EVN">
+              <!-- [C-CDA R1] Pregnancy Observation -->
+              <templateId root="2.16.840.1.113883.10.20.15.3.8" />
+              <!-- [C-CDA PREG] Pregnancy Observation (SUPPLEMENTAL PREGNANCY)-->
+              <templateId root="2.16.840.1.113883.10.20.22.4.293" extension="2018-04-01" />
+              <id root="bab77407-f76d-4a51-a2ed-980c8a59fe28" />
+              <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" />
+              <statusCode code="completed" />
+              <!-- Use the effectiveTime to indicate the date range over which the patient
+                   was pregnant/possibly pregnant/not pregnant/unknown. -->
+              <effectiveTime>
+                <low value="20170826" />
+              </effectiveTime>
+              <!-- eICR Data element: Pregnancy status -->
+              <value xsi:type="CD" code="77386006" displayName="Pregnant" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+              <!-- eICR Data element: Pregnancy status determination method -->
+              <methodCode code="16310003" displayName="Diagnostic ultrasonography (procedure)" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+              <performer>
+                <!-- Pregnancy Status Determination Date -->
+                <time value="20171001" />
+                <assignedEntity>
+                  <id nullFlavor="NA" />
+                </assignedEntity>
+              </performer>
+              <author>
+                <!-- eICR Data element: Pregnancy Status Recorded Date -->
+                <time value="201710011035" />
+                <assignedAuthor>
+                  <id nullFlavor="NA" />
+                </assignedAuthor>
+              </author>
+
+              <!-- Estimated Date of Delivery -->
+              <entryRelationship typeCode="REFR">
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [C-CDA PREG] Estimated Date of Delivery (SUPPLEMENTAL PREGNANCY) -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.297" extension="2018-04-01" />
+                  <id root="f3dfc576-2329-4f71-af3f-d500cab1146b" />
+                  <!-- If method of determination is known, it is included in the code chosen,
+                    if the method of determination is not known,
+                    use code 11778-8 - Delivery Date estimated (no method specified) -->
+                  <!-- eICR Data element: Estimated date of delivery (EDD) method -->
+                  <code code="11780-4" codeSystem="2.16.840.1.113883.6.1" displayName="Delivery date estimated from ovulation date" codeSystemName="LOINC" />
+                  <statusCode code="completed" />
+                  <!-- eICR Data element: EDD determination date -->
+                  <effectiveTime value="201710011015" />
+                  <!-- eICR Data element: Estimated date of delivery (EDD) -->
+                  <value xsi:type="TS" value="20170522" />
+                </observation>
+              </entryRelationship>
+
+              <!-- Estimated Gestational Age of Pregnancy -->
+              <entryRelationship typeCode="REFR">
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [C-CDA PREG] Estimated Gestational Age of Pregnancy  -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.280" extension="2018-04-01" />
+                  <id root="9ae62b42-0e67-4ddc-8ef7-909d03732292" />
+                  <code code="11887-7" codeSystem="2.16.840.1.113883.6.1" displayName="Gestational age Estimated from selected delivery date" codeSystemName="LOINC" />
+                  <statusCode code="completed" />
+                  <!-- eICR Data element: Estimated gestational age determination date -->
+                  <effectiveTime value="201710011015" />
+                  <!-- eICR Data element: Estimated gestational age of pregnancy in days -->
+                  <value xsi:type="PQ" unit="d" value="143" />
+                  <!-- The following entryRelationship only needs to be present if the code used
+                       is 11887-7 | Gestational age Estimated from selected delivery date. The
+                       Entry Reference template points to the relevant Estimated Date of Delivery template-->
+                  <entryRelationship typeCode="REFR">
+                    <act classCode="ACT" moodCode="EVN">
+                      <!-- [C-CDA R2.0] Entry Reference -->
+                      <templateId root="2.16.840.1.113883.10.20.22.4.122" />
+                      <!-- This ID equals the ID of the relevant Estimated Date of Delivery template -->
+                      <id root="f3dfc576-2329-4f71-af3f-d500cab1146b" />
+                      <!-- The code is nulled to "NP" Not Present" -->
+                      <code nullFlavor="NP" />
+                      <statusCode code="completed" />
+                    </act>
+                  </entryRelationship>
+                </observation>
+              </entryRelationship>
+
+              <!-- Pregnancy Outcome -->
+              <entryRelationship typeCode="COMP">
+                <!-- The order born in the delivery, live born or fetal death (1st, 2nd, 3rd, 4th, 5th, 6th, 7th, etc.).
+                     All live births and fetal losses are included. If the pregnancy plurality is 1
+                     then this value will also be 1. -->
+                <sequenceNumber value="1" />
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [C-CDA PREG] Pregnancy Outcome -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.284" extension="2018-04-01" />
+                  <id root="6df3e951-e6f8-441d-a298-d9d6d3f405db" />
+                  <code code="63893-2" codeSystem="2.16.840.1.113883.6.1" displayName="Outcome of Pregnancy" codeSystemName="LOINC" />
+                  <statusCode code="completed" />
+                  <!-- eICR Data element: Pregnancy outcome date -->
+                  <effectiveTime value="201801050850" />
+                  <!-- eICR Data element: Pregnancy outcome -->
+                  <value xsi:type="CD" code="237364002" codeSystem="2.16.840.1.113883.6.96" displayName="Stillbirth (finding)" codeSystemName="SNOMED CT" />
+                </observation>
+              </entryRelationship>
+            </observation>
+          </entry>
+
+          <!-- Last Menstrual Period -->
+          <entry typeCode="DRIV">
+            <observation classCode="OBS" moodCode="EVN">
+              <!-- [COTPS R1D2] Last Menstrual Period (V2) -->
+              <templateId root="2.16.840.1.113883.10.20.30.3.34" extension="2014-06-09" />
+              <id root="5ffea0ae-9ae5-4313-956a-30219b4a6afa" />
+              <code code="8665-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Last menstrual period start date" />
+              <statusCode code="completed" />
+              <!-- eICR Data element: Last menstrual period (LMP) -->
+              <effectiveTime value="201801051015" />
+              <value xsi:type="TS" value="20170801" />
+            </observation>
+          </entry>
+
+          <!-- Postpartum Status -->
+          <entry typeCode="DRIV">
+            <observation classCode="OBS" moodCode="EVN">
+              <!-- [C-CDA PREG] Postpartum Status -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.285" extension="2018-04-01" />
+              <id root="9701b264-0f70-47f9-bfbf-aa4f9686cd3a" />
+              <code code="249197004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Maternal condition during puerperium (observable entity)" />
+              <statusCode code="completed" />
+              <effectiveTime value="201801051015" />
+              <!-- eICR Data element: Postpartum status -->
+              <value xsi:type="CD" code="42814007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Mid postpartum state (finding)" />
+            </observation>
+          </entry>
+        </section>
+      </component>
+      <!--
+          ********************************************************
+          Vital Signs Section (entries required) (V3)
+          ********************************************************
+      -->
+      <component>
+        <section>
+          <!-- [C-CDA R2.1] Vital Signs Section (entries required) (V3) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.4.1" extension="2015-08-01" />
+          <code code="8716-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Vital Signs" />
+          <title>Vital Signs (Last Filed)</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Blood Pressure</th>
+                  <th>Pulse</th>
+                  <th>Temperature</th>
+                  <th>Respiratory Rate</th>
+                  <th>Height</th>
+                  <th>Weight</th>
+                  <th>BMI</th>
+                  <th>SpO2</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>05/20/2014 7:36pm</td>
+                  <!-- You can consolidate Systolic and Diastolic in human view if desired but should retain separate references-->
+                  <td>
+                    <content ID="SystolicBP_2">120</content>/<content ID="DiastolicBP_2">80</content>mm[Hg] </td>
+                  <td ID="Pulse_2">80 /min</td>
+                  <td ID="Temp_2">99.0 F</td>
+                  <td ID="RespRate_2">18 /min</td>
+                  <td ID="Height_2">5'7 (67 inches)</td>
+                  <td ID="Weight_2">239.9 lbs</td>
+                  <td ID="BMI_2">37.58 kg/m2</td>
+                  <td ID="SPO2_2">98%</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <entry typeCode="DRIV">
+            <!-- When a set of vital signs are recorded together, include them in single clustered organizer-->
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.26" />
+              <templateId root="2.16.840.1.113883.10.20.22.4.26" extension="2015-08-01" />
+              <id root="e421f5c8-29c2-4798-9cb5-7988c236e49d" />
+              <code code="46680005" displayName="Vital Signs" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                <translation code="74728-7" displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel "
+                  codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+              </code>
+              <statusCode code="completed" />
+              <effectiveTime value="20140520193605-0500" />
+              <!-- Each vital sign should be its own component. Note that systolic and diastolic BP must be separate components-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+                  <id root="2721acc5-0d05-4402-9e62-79943ea3901c" />
+                  <code code="8480-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="SYSTOLIC BLOOD PRESSURE" />
+                  <text>
+                    <!-- This reference identifies content in human readable formatted text-->
+                    <reference value="#SystolicBP_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <!-- Example of Value with UCUM unit. Note that mixed metric and imperial units used in this example-->
+                  <value xsi:type="PQ" value="120" unit="mm[Hg]" />
+                  <!-- Additional information of interpretation and/or reference range may be included but are optional-->
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+                  <id root="88a01c83-a096-4705-a992-b5f59eca8c8c" />
+                  <code code="8462-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="DIASTOLIC BLOOD PRESSURE" />
+                  <text>
+                    <reference value="#DiastolicBP_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <value xsi:type="PQ" value="80" unit="mm[Hg]" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+                  <id root="83bbffe1-54e5-4984-a32d-ad8f8d6896d8" />
+                  <code code="8867-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="HEART RATE" />
+                  <text>
+                    <reference value="#Pulse_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <value xsi:type="PQ" value="80" unit="/min" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+                  <id root="85f5784f-2958-4321-b7b6-3030d1577dc0" />
+                  <code code="8310-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="BODY TEMPERATURE" />
+                  <text>
+                    <reference value="#Temp_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <!-- Note the UCUM conformant way to specify degrees Farenheit-->
+                  <value xsi:type="PQ" value="99.0" unit="[degF]" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+                  <id root="b618fa98-6596-4e19-a9e7-6bdb48012fc8" />
+                  <code code="9279-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="RESPIRATORY RATE" />
+                  <text>
+                    <reference value="#RespRate_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <value xsi:type="PQ" value="18" unit="/min" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+                  <id root="1b1274a9-b45f-449a-8493-08eaeaeba7d6" />
+                  <code code="8302-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="HEIGHT" />
+                  <text>
+                    <reference value="#Height_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <!-- Note the UCUM conformant way to specify inches-->
+                  <value xsi:type="PQ" value="67" unit="[in_us]" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+                  <id root="1c1f89f1-8e93-4a46-b37f-9434f99727b8" />
+                  <code code="3141-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="WEIGHT" />
+                  <text>
+                    <reference value="#Weight_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <!-- Note the UCUM conformant way to specify pounds-->
+                  <value xsi:type="PQ" value="239.9" unit="[lb_av]" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+                  <id root="fd4ccd0b-c045-4587-8976-a17e2e064a1e" />
+                  <code code="39156-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="BODY MASS INDEX" />
+                  <text>
+                    <reference value="#BMI_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <value xsi:type="PQ" value="37.58" unit="kg/m2" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+                  <id root="0ef4afda-1638-4ad2-9978-7321bbceb0cb" />
+                  <code code="2710-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="OXYGEN SATURATION" />
+                  <text>
+                    <reference value="#SPO2_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <value xsi:type="PQ" value="98" unit="%" />
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/data/Templates/eCR/Resource/_MedicationAdministration.liquid
+++ b/data/Templates/eCR/Resource/_MedicationAdministration.liquid
@@ -12,12 +12,16 @@
         ],
         "status":"{{ medicationAdministration.statusCode.code | get_property: 'ValueSet/MedicationAdministrationStatus' }}",
         {% assign effectiveTimes = medicationAdministration.effectiveTime | to_array -%}
-        {% for effectiveTime in effectiveTimes %}
-            {% if effectiveTime.operator != "A" %}
-                {%  comment  %} only one of the times should actually return anything here {% endcomment %}
-                {% include 'Utils/EffectiveTime' effectiveTime: effectiveTime %}
-            {% endif %}
-        {% endfor %}
+        {%- if effectiveTimes | size == 1 and medicationAdministration.effectiveTime.value -%}
+            {% include 'Utils/EffectiveTime' effectiveTime: medicationAdministration.effectiveTime %}
+        {%- else -%}
+            {% for effectiveTime in effectiveTimes %}
+                {% if effectiveTime.operator != "A" %}
+                    {%  comment  %} only one of the times should actually return anything here {% endcomment %}
+                    {% include 'Utils/EffectiveTime' effectiveTime: effectiveTime %}
+                {% endif %}
+            {% endfor %}
+        {%- endif -%}
         "dosage":
         {
             "route":

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/BaseConvertDataFunctionalTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/BaseConvertDataFunctionalTests.cs
@@ -243,6 +243,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests
                 new[] { @"EICR", @"eCR_RR_combined_3_1.xml", @"eCR_RR_combined_3_1-expected.json", "parsing", "1" },
                 new[] { @"EICR", @"eCR_EveEverywoman.xml", @"eCR_EveEverywoman-expected.json", "validation", "63" },
                 new[] { @"EICR", @"eicr04152020.xml", @"eicr04152020-expected.json", "validation", "23" },
+                new[] { @"EICR", @"CDAR2_IG_PHCASERPT_R2_D2_SAMPLE.xml", @"CDAR2_IG_PHCASERPT_R2_D2_SAMPLE-expected.json", "validation", "34" },
             };
             return data.Select(item => new[]
             {

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/CDAR2_IG_PHCASERPT_R2_D2_SAMPLE-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/CDAR2_IG_PHCASERPT_R2_D2_SAMPLE-expected.json
@@ -1,0 +1,2942 @@
+{
+  "resourceType": "Bundle",
+  "type": "batch",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:db734647-fc99-424c-a864-7e3cda82e704",
+      "resource": {
+        "resourceType": "Composition",
+        "id": "db734647-fc99-424c-a864-7e3cda82e704",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/eicr-composition"
+          ]
+        },
+        "identifier": {
+          "use": "official",
+          "type": {
+            "coding": [
+              {
+                "code": "55751-2",
+                "system": "http://loinc.org",
+                "display": "Public Health Case Report"
+              }
+            ]
+          },
+          "value": "31"
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/composition-clinicaldocument-versionNumber",
+            "valueString": "2"
+          },
+          {
+            "url": "https://www.hl7.org/implement/standards/product_brief.cfm?product_id=436",
+            "valueString": "2019-04-01"
+          }
+        ],
+        "status": "final",
+        "type": {
+          "coding": [
+            {
+              "code": "55751-2",
+              "system": "http://loinc.org",
+              "display": "Public Health Case Report"
+            }
+          ]
+        },
+        "date": "2018-11-07T09:44:21-05:00",
+        "title": "Initial Public Health Case Report",
+        "confidentiality": "N",
+        "section": [
+          {
+            "id": "65430f0b-1a9a-b6bd-9648-ab44350d5794",
+            "title": "Plan of Treatment",
+            "text": {
+              "status": "generated",
+              "div": "<table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Initial Case Report Trigger<br />Code Lab Test Order</th><th>Trigger Code</th><th>Trigger Code codeSystem</th><th>RCTC OID</th><th>RCTC Version</th><th>Ordered Date</th></tr></thead><tbody><tr ID=\"id_b52bee94-c34b-4e2c-8c15-5ad9d6def205_ref\"><td>Zika virus envelope (E) gene [Presence] in Serum<br />by Probe and target amplification method</td><td>80825-3</td><td>LOINC</td><td>2.16.840.1.114222.4.11.7508</td><td>19/05/2018</td><td>NOV 8, 2018</td></tr></tbody></table>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "18776-5",
+                  "system": "http://loinc.org",
+                  "display": "Plan of Treatment"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "1caa3252-d724-801f-5f8c-8cbf7dad60f4",
+            "title": "Encounters",
+            "text": {
+              "status": "generated",
+              "div": "<table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Encounter</th><th>Date(s)</th><th>Location</th></tr></thead><tbody><tr ID=\"id_2a620155-9d11-439e-92b3-5d9815ff4de8_ref\"><td>Office outpatient visit 15 minutes</td><td>NOV 7, 2018</td><td><list styleCode=\"none\"><item><content styleCode=\"Italics\">Urgent Care Center</content></item></list></td></tr><tr><td colspan=\"20\"><list styleCode=\"none\"><item><table><thead><tr><th>Encounter Diagnosis Type</th></tr></thead><tbody><tr><td>Diagnosis</td></tr><tr><td colspan=\"20\"><list styleCode=\"none\"><item><table><thead><tr><th>Initial Case Report Trigger<br />Code Problem Observation </th><th>Problem</th><th>Trigger Code</th><th>Trigger Code codeSystem</th><th>RCTC OID</th><th>RCTC Version</th><th>Date(s)</th></tr></thead><tbody><tr ID=\"id_db734647-fc99-424c-a864-7e3cda82e705_ref\"><td>Diagnosis</td><td>Pertussis (disorder)</td><td>27836007</td><td>SNOMED CT</td><td>2.16.840.1.114222.4.11.7508</td><td>19/05/2018</td><td>NOV 7, 2018</td></tr></tbody></table><table><thead><tr><th>Encounter Diagnosis Type</th></tr></thead><tbody><tr><td>Diagnosis</td></tr><tr><td colspan=\"20\"><list styleCode=\"none\"><item><table><thead><tr><th>Problem Type</th><th>Problem</th><th>Date(s)</th></tr></thead><tbody><tr ID=\"id_db734647-fc99-424c-a864-7e3cda82e704_ref\"><td>Diagnosis</td><td>A non-trigger code diagnosis (disorder)</td><td>NOV 7, 2018</td></tr></tbody></table></item></list></td></tr></tbody></table></item></list></td></tr></tbody></table></item></list></td></tr></tbody></table>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "46240-8",
+                  "system": "http://loinc.org",
+                  "display": "History of encounters"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "c2093bef-fcc6-95a1-b54b-9d7f57e2ac07",
+            "title": "History of Present Illness",
+            "text": {
+              "status": "generated",
+              "div": "<paragraph xmlns=\"urn:hl7-org:v3\"> Persistent Cough REPORTED starting on 2018/10/05<br /> Whooping Respiration not reported<br /> Paroxysms Of Coughing REPORTED starting on 2018/11/04<br /> Post-tussive vomiting not reported<br /></paragraph>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "10164-2",
+                  "system": "http://loinc.org",
+                  "display": "HISTORY OF PRESENT ILLNESS"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "24e9b0a5-f614-0843-54d6-ba8a6dd0e87e",
+            "title": "Medications Administered",
+            "text": {
+              "status": "generated",
+              "div": "<table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Medication</th><th>Dose</th><th>Duration</th><th>Route</th></tr></thead><tbody><tr ID=\"id_6c844c75-aa34-411c-b7bd-5e4a9f206e29_ref\"><td>Azithromycin 500 MG Oral Tablet</td><td>1 g</td><td>NOV 7, 2018 11:60</td><td>ORAL</td></tr></tbody></table>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "29549-3",
+                  "system": "http://loinc.org",
+                  "display": "Medications Administered"
+                }
+              ]
+            },
+            "mode": "snapshot",
+            "entry": [
+              {
+                "reference": "MedicationAdministration/36eb4fec-db62-8fc1-e586-fd76adbc37d0"
+              }
+            ]
+          },
+          {
+            "id": "f0060761-a5e8-73e0-7ee8-d1b73db6b3a5",
+            "title": "Problems",
+            "text": {
+              "status": "generated",
+              "div": "<table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Concern</th><th>Concern Status</th><th>Date(s)</th></tr></thead><tbody><tr ID=\"id_ec8a6ff8-ed4b-4f7e-82c3-e98e58b45de7_ref\"><td>Problem</td><td>active</td><td>NOV 7, 2018</td></tr><tr><td colspan=\"20\"><list styleCode=\"none\"><item><table><thead><tr><th>Problem Type</th><th>Problem</th><th>Date(s)</th></tr></thead><tbody><tr ID=\"id_ab1791b0-5c71-11db-b0de-0800200c9a66_ref\"><td>Symptom</td><td>Dark stools (finding)</td><td>NOV 1, 2018</td></tr><tr ID=\"id_ab1791b0-5c71-11db-b0de-0800200c9a67_ref\"><td>Complaint</td><td>Paroxysmal cough (finding)</td><td>NOV 4, 2018</td></tr></tbody></table></item></list></td></tr></tbody></table><table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Concern</th><th>Concern Status</th><th>Date(s)</th></tr></thead><tbody><tr ID=\"id_ec8a6ff8-ed4b-4f7e-82c3-e98e58b45de8_ref\"><td>Problem</td><td>active</td><td>MAY 23, 2018</td></tr></tbody></table>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "11450-4",
+                  "system": "http://loinc.org",
+                  "display": "Problem List"
+                }
+              ]
+            },
+            "mode": "snapshot",
+            "entry": [
+              {
+                "display": "Problem - Dark stools (finding)",
+                "reference": "Condition/028492eb-66b8-658a-b1e9-9ecad7530ceb"
+              },
+              {
+                "display": "Problem - Paroxysmal cough (finding)",
+                "reference": "Condition/bf6251d6-2a69-ab5d-d0f5-f91779b7cfe0"
+              },
+              {
+                "display": "Problem - Dark stools (finding)",
+                "reference": "Condition/028492eb-66b8-658a-b1e9-9ecad7530ceb"
+              },
+              {
+                "display": "Problem - Paroxysmal cough (finding)",
+                "reference": "Condition/bf6251d6-2a69-ab5d-d0f5-f91779b7cfe0"
+              }
+            ]
+          },
+          {
+            "id": "e40cdafc-baa4-5531-690e-4140be6252ce",
+            "title": "Reason for Visit",
+            "text": {
+              "status": "generated",
+              "div": "<paragraph xmlns=\"urn:hl7-org:v3\">Dark stools</paragraph>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "29299-5",
+                  "system": "http://loinc.org",
+                  "display": "Reason for visit"
+                }
+              ]
+            },
+            "mode": "snapshot",
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/cda/ccda/StructureDefinition/2.16.840.1.113883.10.20.22.2.12",
+                "valueString": "Dark stools"
+              }
+            ]
+          },
+          {
+            "id": "d887e17f-f7d9-15f6-24e0-73c549af07d6",
+            "title": "Results",
+            "text": {
+              "status": "generated",
+              "div": "<table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Results Panel</th><th>Date(s)</th></tr></thead><tbody><tr ID=\"id_7d5a02b0-67a4-11db-bd13-0800200c9a66_ref\"><td>CBC W Auto Differential panel in Blood</td><td>NOV 7, 2018 to NOV 7, 2018</td></tr><tr><td colspan=\"20\"><list styleCode=\"none\"><item><table><thead><tr><th>Test</th><th>Outcome</th><th>Interpretation</th><th>Date(s)</th><th>Reference Range</th><th>Reference Range Interpretation</th><th>Reference Range Description</th></tr></thead><tbody><tr ID=\"id_7c0704bb-9c40-41b5-9c7d-26b2d59e234f_ref\"><td>Hematocrit</td><td>35.3 %</td><td>Low</td><td>NOV 7, 2018</td><td>34.9 % to 44.5 %</td><td>Low</td><td>Low</td></tr><tr ID=\"id_7c0704bb-9c40-41b5-9c7d-26b2d59e234g_ref\"><td>Lymphocytes [#/​volume] in Blood by Automated count</td><td>5.2 10*3/uL</td><td>High</td><td>NOV 7, 2018</td><td>1.0 10*3/uL to 4.8 10*3/uL</td><td>Normal</td><td /></tr></tbody></table></item></list></td></tr></tbody></table><table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Results Panel</th><th>Date(s)</th></tr></thead><tbody><tr ID=\"id_a4307cb2-b3b4-4f42-be03-1d9077376f4a_ref\"><td>Bordetella pertussis Ab<br />[Units/volume] in Serum</td><td>NOV 7, 2018 to NOV 7, 2018</td></tr><tr><td colspan=\"20\"><list styleCode=\"none\"><item><table><thead><tr><th>Initial Case Report Trigger<br />Code Result Observation </th><th>Trigger Code</th><th>Trigger Code codeSystem</th><th>RCTC OID</th><th>RCTC Version</th><th>Outcome</th><th>Interpretation</th><th>Date(s)</th><th>Reference Range</th><th>Reference Range Interpretation</th></tr></thead><tbody><tr ID=\"id_bf9c0a26-4524-4395-b3ce-100450b9c9ad_ref\"><td>Bordetella pertussis Ab<br />[Units/volume] in Serum</td><td>11585-7</td><td>LOINC</td><td>2.16.840.1.114222.4.11.7508</td><td>19/05/2018</td><td>100 [iU]/mL</td><td>High</td><td>NOV 7, 2018</td><td> to 45 [iU]/mL</td><td>Normal</td></tr></tbody></table></item></list></td></tr></tbody></table><table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Results Panel</th><th>Date(s)</th></tr></thead><tbody><tr ID=\"id_a4307cb2-b3b4-4f42-be03-1d9077376f4b_ref\"><td>Bordetella pertussis [Presence]<br />in Throat by Organism specific culture</td><td>NOV 7, 2018 to NOV 7, 2018</td></tr><tr><td colspan=\"20\"><list styleCode=\"none\"><item><table><thead><tr><th>Initial Case Report Trigger Code Result Observation </th><th>Trigger Code</th><th>Trigger Code codeSystem</th><th>RCTC OID</th><th>RCTC Version</th><th>Outcome</th><th>Trigger Code</th><th>Trigger Code codeSystem</th><th>RCTC OID</th><th>RCTC Version</th><th>Interpretation</th><th>Date(s)</th></tr></thead><tbody><tr ID=\"id_bf9c0a26-4524-4395-b3ce-100450b9c9ac_ref\"><td>Bordetella pertussis [Presence]<br />in Throat by Organism specific culture</td><td>548-8</td><td>LOINC</td><td>2.16.840.1.114222.4.11.7508</td><td>19/05/2018</td><td>Bordetella pertussis (organism)</td><td>5247005</td><td>SNOMED CT</td><td>2.16.840.1.114222.4.11.7508</td><td>19/05/2018</td><td>Abnormal</td><td>NOV 7, 2018</td></tr></tbody></table></item></list></td></tr></tbody></table>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "30954-2",
+                  "system": "http://loinc.org",
+                  "display": "Relevant diagnostic tests and/or laboratory data"
+                }
+              ]
+            },
+            "mode": "snapshot",
+            "entry": [
+              {
+                "reference": "Observation/542cf409-a330-2185-6cfc-7f7f20d593c8"
+              },
+              {
+                "reference": "Observation/fe859df1-071e-3927-dcaa-9f511660a24d"
+              },
+              {
+                "reference": "Observation/d5a75751-35da-5ce1-936d-42a4b765febb"
+              },
+              {
+                "reference": "Observation/6235785d-3468-42dc-8c76-d4c70d67f2e9"
+              },
+              {
+                "reference": "Observation/145a35c6-8d22-9a2c-a1f9-2962a6586b3e",
+                "display": "Bordetella pertussis [Presence] in Throat by Organism specific culture"
+              }
+            ]
+          },
+          {
+            "id": "0677166e-0d81-2868-5676-611c7a72fdda",
+            "title": "Immunizations",
+            "text": {
+              "status": "generated",
+              "div": "<table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Immunization</th><th>Immunization Date</th></tr></thead><tbody><tr><td>diphtheria, tetanus toxoids and acellular<br />pertussis vaccine, 5 pertussis antigens</td><td>NOV 11, 2018</td></tr></tbody></table><table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Initial Case Report Trigger Code<br />Immunization Medication Activity</th><th>Immunization Date</th><th>Trigger<br />Code</th><th>Trigger Code<br />codeSystem</th><th>RCTC OID</th><th>RCTC<br />Version</th></tr></thead><tbody><tr><td>influenza virus vaccine, unspecified formulation</td><td>NOV 11, 2018</td><td>88</td><td>CVX</td><td>2.16.840.1.114222.4.11.7508</td><td>19/05/2018</td></tr></tbody></table>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "11369-6",
+                  "system": "http://loinc.org",
+                  "display": "Hx of Immunization"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          },
+          {
+            "id": "9cf99ab0-8905-d839-b313-98cbc80ee805",
+            "title": "Social History",
+            "text": {
+              "status": "generated",
+              "div": "<table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Birth Sex</th><th>Value</th><th>Date</th></tr></thead><tbody><tr><td>Sex Assigned At Birth</td><td>Female</td><td>NOV 24, 1974</td></tr></tbody></table><table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Gender identity</th><th>Date</th></tr></thead><tbody><tr><td>Female-to-male transsexual (finding)</td><td>JAN 1, 2018</td></tr></tbody></table><table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Characteristics of Home Environment</th><th>Date</th></tr></thead><tbody><tr><td>Homeless</td><td>NOV 9, 2018</td></tr></tbody></table><table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Current Occupation</th><th>Current Industry</th><th>Current Job Title</th><th>Current Employer</th></tr></thead><tbody><tr><td>Actuaries</td><td>Accounting, tax preparation, bookkeeping, and payroll services</td><td>Senior Accountant</td><td>CDC, Peachtree St, Ann Arbor Georgia, 555-1212</td></tr></tbody></table><table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Usual Occupation</th><th>Usual Industry</th><th>Occupational Exposure</th></tr></thead><tbody><tr><td>Actuaries</td><td>Accounting, tax preparation, bookkeeping, and payroll services</td><td>Asbestos</td></tr></tbody></table><table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Travel History: Date(s)</th><th>Notes</th><th>Location</th></tr></thead><tbody><tr><td>1999 to 2007</td><td>Spent 8 years in the UK during the BSE outbreak</td><td /></tr><tr><td>In the 3 weeks before NOV 9, 2018</td><td /><td><list styleCode=\"none\"><item>Brazil</item></list></td></tr><tr><td>APR 25, 2018 to APR 30, 2018</td><td /><td><list styleCode=\"none\"><item>Nadi, FJ</item></list></td></tr><tr><td>MAY 6, 2018 to MAY 15, 2018</td><td /><td><list styleCode=\"none\"><item>Montreal, QC, CA</item></list></td></tr><tr><td>JUL 13, 2018 to JUL 15, 2018</td><td /><td><list styleCode=\"none\"><item>Sydney, NSW, AU</item></list></td></tr><tr><td>OCT 22, 2018 to OCT 30, 2018</td><td /><td><list styleCode=\"none\"><item>1170 N Rancho Robles Rd Oracle, AZ8562, US</item></list></td></tr></tbody></table>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "29762-2",
+                  "system": "http://loinc.org",
+                  "display": "Social History"
+                }
+              ]
+            },
+            "mode": "snapshot",
+            "entry": [
+              {
+                "reference": "Observation/32076aed-d020-9b44-d756-327a72167578"
+              },
+              {
+                "reference": "Observation/41fb62f4-0827-2a1a-c85e-afc77b2c92d5"
+              },
+              {
+                "reference": "Observation/e419541c-79fc-a50e-6c78-f93b7715fc88"
+              },
+              {
+                "reference": "Observation/d5b5f6ce-cd21-c9a0-5778-e5276364c153"
+              },
+              {
+                "reference": "Observation/e0b83dcd-dced-1a38-d82a-eca78198428b"
+              },
+              {
+                "reference": "Observation/8b536f6b-b441-948d-764c-517fa4869ddd"
+              },
+              {
+                "reference": "Observation/8a65af49-3816-ab97-1179-3ebe9c728122"
+              },
+              {
+                "reference": "Observation/6770d2f8-c964-aac6-b8c2-df22bba56b7a"
+              },
+              {
+                "reference": "Observation/033923b6-9c24-956e-21c2-b8e2478bc446"
+              }
+            ]
+          },
+          {
+            "id": "62713e64-f46d-6fce-db3c-bbe9d8850be4",
+            "title": "Pregnancy Section",
+            "text": {
+              "status": "generated",
+              "div": "<table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Pregnancy Status</th><th>Date(s) over which status holds<br />(if no high date, status was<br />current at time of recording)</th><th>Determination Method</th><th>Determination Date</th><th>Recorded Date</th></tr></thead><tbody><tr><td>Pregnant</td><td>AUG 26, 2017</td><td>Diagnostic ultrasonography</td><td>OCT 1, 2017</td><td>OCT 1, 2017 10:35</td></tr><tr><td colspan=\"20\"><list styleCode=\"none\"><item><table><thead><tr><th>Estimated Date of Delivery</th><th>EDD</th><th>EDD Determination Date</th></tr></thead><tbody><tr><td>Delivery date estimated from ovulation date</td><td>MAY 22, 2017</td><td>OCT 1, 2017 10:15</td></tr></tbody></table><table><thead><tr><th>Estimated Gestational Age of Pregnancy</th><th>Days</th><th>Determination Date</th></tr></thead><tbody><tr><td>Gestational age Estimated from selected delivery date</td><td>143 d</td><td>OCT 1, 2017 10:15</td></tr><tr><td colspan=\"20\"><list styleCode=\"none\"><item><table><thead><tr><th>Reference to selected delivery date</th></tr></thead><tbody><tr><td><linkHtml href=\"#id_f3dfc576-2329-4f71-af3f-d500cab1146b_ref\">Link to referenced entry</linkHtml></td></tr></tbody></table></item></list></td></tr></tbody></table><table><thead><tr><th>Pregnancy Outcome</th><th>Birth Order</th><th>Time</th><th>Method of Delivery</th></tr></thead><tbody><tr><td>Stillbirth (finding)</td><td>1</td><td>JAN 5, 2018 08:50</td><td>Breech delivery (procedure)</td></tr><tr><td>Term birth of newborn (finding)</td><td>2</td><td>JAN 5, 2018 10:05</td><td>Breech delivery (procedure)</td></tr></tbody></table></item></list></td></tr></tbody></table><table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Last menstrual period start date</th><th>Observation Date</th></tr></thead><tbody><tr><td>AUG 1, 2017</td><td>JAN 5, 2018 10:15</td></tr></tbody></table><table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Postpartum Status</th><th>Observation date</th></tr></thead><tbody><tr><td>Mid postpartum state (finding)</td><td>JAN 5, 2018 10:15</td></tr></tbody></table>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "90767-5",
+                  "system": "http://loinc.org",
+                  "display": "Pregnancy summary Document"
+                }
+              ]
+            },
+            "mode": "snapshot",
+            "entry": [
+              {
+                "reference": "Observation/971025bd-d2cd-6731-e9f1-7d51fbeea207"
+              },
+              {
+                "reference": "Observation/971025bd-d2cd-6731-e9f1-7d51fbeea207"
+              },
+              {
+                "reference": "Observation/e918b73b-aad0-4797-3ee3-ff8b96d3a054"
+              },
+              {
+                "reference": "Observation/4e7f8ad6-3b2a-91e0-0d2a-42f0b0d5719d"
+              }
+            ]
+          },
+          {
+            "id": "90120268-e0d0-1e15-cf91-846ac22a9af7",
+            "title": "Vital Signs (Last Filed)",
+            "text": {
+              "status": "generated",
+              "div": "<table xmlns=\"urn:hl7-org:v3\"><thead><tr><th>Date</th><th>Blood Pressure</th><th>Pulse</th><th>Temperature</th><th>Respiratory Rate</th><th>Height</th><th>Weight</th><th>BMI</th><th>SpO2</th></tr></thead><tbody><tr><td>05/20/2014 7:36pm</td><!-- You can consolidate Systolic and Diastolic in human view if desired but should retain separate references--><td><content ID=\"SystolicBP_2\">120</content>/<content ID=\"DiastolicBP_2\">80</content>mm[Hg] </td><td ID=\"Pulse_2\">80 /min</td><td ID=\"Temp_2\">99.0 F</td><td ID=\"RespRate_2\">18 /min</td><td ID=\"Height_2\">5'7 (67 inches)</td><td ID=\"Weight_2\">239.9 lbs</td><td ID=\"BMI_2\">37.58 kg/m2</td><td ID=\"SPO2_2\">98%</td></tr></tbody></table>"
+            },
+            "code": {
+              "coding": [
+                {
+                  "code": "8716-3",
+                  "system": "http://loinc.org",
+                  "display": "Vital Signs"
+                }
+              ]
+            },
+            "mode": "snapshot"
+          }
+        ],
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        },
+        "relatesTo": [
+          {
+            "code": "replaces",
+            "targetReference": {
+              "reference": "Composition/2.16.840.1.113883.9.9.9.9.9"
+            },
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/composition-clinicaldocument-versionNumber",
+                "valueString": "1"
+              }
+            ]
+          }
+        ],
+        "encounter": {
+          "reference": "Encounter/e643736c-3539-57f5-a34d-66a1aa2ca08b"
+        },
+        "custodian": {
+          "reference": "Organization/6f0890ee-d9a6-c51d-ac83-79cfda623a82"
+        },
+        "author": [
+          {
+            "reference": "Device/d0ae0527-f36b-de1d-e26b-1560599be6d5"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Composition/db734647-fc99-424c-a864-7e3cda82e704"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:e643736c-3539-57f5-a34d-66a1aa2ca08b",
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "e643736c-3539-57f5-a34d-66a1aa2ca08b",
+        "status": "unknown",
+        "class": {
+          "code": "AMB",
+          "system": "urn:oid:2.16.840.1.113883.5.4",
+          "display": "Ambulatory"
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:2.16.840.1.113883.19",
+            "value": "9937012"
+          }
+        ],
+        "period": {
+          "start": "2018-11-07"
+        },
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        },
+        "location": [
+          {
+            "id": "2.16.840.1.113883.4.6",
+            "location": {
+              "reference": "Location/14383c1c-7f95-3974-3e55-9d730de06b9e",
+              "display": "Good Health Hospital"
+            },
+            "extension": [
+              {
+                "url": "http://build.fhir.org/ig/HL7/case-reporting/StructureDefinition-us-ph-location-definitions.html#Location.type",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "code": "OF",
+                      "system": "urn:oid:2.16.840.1.113883.5.111",
+                      "display": "Outpatient facility"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "serviceProvider": {
+          "reference": "Organization/09e89134-7d55-51b4-2183-bcb51b361a36"
+        },
+        "participant": [
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code": "ATND"
+                  }
+                ]
+              }
+            ],
+            "individual": {
+              "reference": "PractitionerRole/ee172968-bee0-e42b-1901-83480bd97c51"
+            }
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Encounter/e643736c-3539-57f5-a34d-66a1aa2ca08b"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:14383c1c-7f95-3974-3e55-9d730de06b9e",
+      "resource": {
+        "resourceType": "Location",
+        "id": "14383c1c-7f95-3974-3e55-9d730de06b9e",
+        "identifier": [
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "77777777777"
+          }
+        ],
+        "name": "Good Health Hospital",
+        "address": {
+          "line": [
+            "1000 Hospital Lane"
+          ],
+          "city": "Ann Arbor",
+          "state": "MI",
+          "country": "US",
+          "postalCode": "99999"
+        },
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "1+(555)-555-1212",
+            "use": "work"
+          },
+          {
+            "system": "fax",
+            "value": "1+(555)-555-3333",
+            "use": "work"
+          }
+        ],
+        "type": [
+          {
+            "coding": [
+              {
+                "code": "OF",
+                "system": "urn:oid:2.16.840.1.113883.5.111",
+                "display": "Outpatient facility"
+              }
+            ]
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Location/14383c1c-7f95-3974-3e55-9d730de06b9e"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:09e89134-7d55-51b4-2183-bcb51b361a36",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "09e89134-7d55-51b4-2183-bcb51b361a36",
+        "name": "Good Health Hospital",
+        "address": [
+          {
+            "line": [
+              "1000 Hospital Lane"
+            ],
+            "city": "Ann Arbor",
+            "state": "MI",
+            "country": "US",
+            "postalCode": "99999"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "1+(555)-555-1212",
+            "use": "work"
+          },
+          {
+            "system": "fax",
+            "value": "1+(555)-555-3333",
+            "use": "work"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/09e89134-7d55-51b4-2183-bcb51b361a36"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:b1788a7c-7165-936d-d3de-3a1713e2d54d",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "b1788a7c-7165-936d-d3de-3a1713e2d54d",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/_datatype",
+            "valueString": "Responsible Party"
+          }
+        ],
+        "identifier": [
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "6666666666666"
+          }
+        ],
+        "name": [
+          {
+            "family": "Seven",
+            "given": [
+              "Henry"
+            ],
+            "suffix": [
+              "M.D."
+            ]
+          }
+        ],
+        "address": [
+          {
+            "line": [
+              "1002 Healthcare Drive"
+            ],
+            "city": "Ann Arbor",
+            "state": "MI",
+            "country": "US",
+            "postalCode": "99999"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+1(555)555-1003",
+            "use": "work"
+          },
+          {
+            "system": "fax",
+            "value": "+1(555)555-1234",
+            "use": "work"
+          },
+          {
+            "system": "email",
+            "value": "mail@provider_domain.com",
+            "use": "work"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Practitioner/b1788a7c-7165-936d-d3de-3a1713e2d54d"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "PractitionerRole",
+        "id": "ee172968-bee0-e42b-1901-83480bd97c51",
+        "practitioner": {
+          "reference": "Practitioner/b1788a7c-7165-936d-d3de-3a1713e2d54d"
+        },
+        "organization": {
+          "reference": "Organization/8305a99c-dd44-f037-9a4a-b22ef7ae7d5e"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:8305a99c-dd44-f037-9a4a-b22ef7ae7d5e",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "8305a99c-dd44-f037-9a4a-b22ef7ae7d5e",
+        "name": "Community Health and Hospitals",
+        "address": [
+          {
+            "line": [
+              "1002 Healthcare Drive"
+            ],
+            "city": "Ann Arbor",
+            "state": "MI",
+            "country": "US",
+            "postalCode": "99999"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/8305a99c-dd44-f037-9a4a-b22ef7ae7d5e"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:6f0890ee-d9a6-c51d-ac83-79cfda623a82",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "6f0890ee-d9a6-c51d-ac83-79cfda623a82",
+        "identifier": [
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "88888888"
+          }
+        ],
+        "name": "Good Health Hospital",
+        "address": [
+          {
+            "line": [
+              "1000 Hospital Lane"
+            ],
+            "city": "Ann Arbor",
+            "state": "MI",
+            "country": "US",
+            "postalCode": "99999"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+1(555)555-1212",
+            "use": "work"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/6f0890ee-d9a6-c51d-ac83-79cfda623a82"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:d0ae0527-f36b-de1d-e26b-1560599be6d5",
+      "resource": {
+        "resourceType": "Device",
+        "id": "d0ae0527-f36b-de1d-e26b-1560599be6d5",
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:oid:2.16.840.1.113883.3.72.5.20"
+          }
+        ],
+        "property": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://hl7.org/fhir/device-category",
+                  "code": "software",
+                  "display": "software"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Device/d0ae0527-f36b-de1d-e26b-1560599be6d5"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:f238f1ae-2f55-cd21-5c90-5e68a10af8ce",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "f238f1ae-2f55-cd21-5c90-5e68a10af8ce",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:oid:2.16.840.1.113883.19.5",
+            "value": "123453"
+          },
+          {
+            "system": "http://hl7.org/fhir/sid/us-ssn",
+            "value": "444-22-2222"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "Everywoman",
+            "given": [
+              "Eve",
+              "H"
+            ]
+          },
+          {
+            "use": "usual",
+            "family": "Everywoman",
+            "given": [
+              "Ruth",
+              "L"
+            ]
+          }
+        ],
+        "birthDate": "1974-11-24",
+        "deceasedBoolean": false,
+        "gender": "female",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+            "extension": [
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "code": "2106-3",
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "display": "White"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "White"
+              }
+            ]
+          },
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+            "extension": [
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "code": "2186-5",
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "display": "Not Hispanic or Latino"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "Not Hispanic or Latino"
+              }
+            ]
+          },
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+            "extension": [
+              {
+                "url": "value",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "code": "F",
+                      "system": "urn:oid:2.16.840.1.113883.5.1",
+                      "display": "Female"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-genderidentity-extension",
+            "extension": [
+              {
+                "url": "value",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "code": "407377005",
+                      "system": "http://snomed.info/sct",
+                      "display": "Female-to-male transsexual (finding)"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "address": [
+          {
+            "use": "home",
+            "line": [
+              "2222 Home Street"
+            ],
+            "city": "Ann Arbor",
+            "state": "MI",
+            "country": "US",
+            "postalCode": "99999",
+            "district": "26001"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+1-555-555-2003",
+            "use": "home"
+          },
+          {
+            "system": "phone",
+            "value": "+1-555-555-2004",
+            "use": "work"
+          }
+        ],
+        "communication": [
+          {
+            "language": {
+              "coding": [
+                {
+                  "system": "urn:ietf:bcp:47",
+                  "code": "en",
+                  "display": "English"
+                }
+              ]
+            },
+            "preferred": true,
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/patient-proficiency",
+                "extension": [
+                  {
+                    "url": "type",
+                    "valueCoding": {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-LanguageAbilityMode",
+                      "code": "ESP",
+                      "display": "Expressed spoken"
+                    }
+                  },
+                  {
+                    "url": "level",
+                    "valueCoding": {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-LanguageAbilityProficiency",
+                      "code": "G",
+                      "display": "Good"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:36eb4fec-db62-8fc1-e586-fd76adbc37d0",
+      "resource": {
+        "resourceType": "MedicationAdministration",
+        "id": "36eb4fec-db62-8fc1-e586-fd76adbc37d0",
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:6c844c75-aa34-411c-b7bd-5e4a9f206e29"
+          }
+        ],
+        "status": "completed",
+        "effectiveDateTime": "2018-11-07T12:00:00-07:00",
+        "dosage": {
+          "route": {
+            "coding": [
+              {
+                "code": "C38288",
+                "system": "urn:oid:2.16.840.1.113883.3.26.1.1",
+                "display": "ORAL"
+              }
+            ]
+          }
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-therapeutic-medication-response-extension",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "code": "268910001",
+                  "system": "http://snomed.info/sct",
+                  "display": "Patient's condition improved (finding)"
+                }
+              ]
+            }
+          }
+        ],
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        },
+        "medicationReference": {
+          "reference": "Medication/da82c76b-25ec-2365-8e57-4e7ec4f8f174"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "MedicationAdministration/36eb4fec-db62-8fc1-e586-fd76adbc37d0"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:da82c76b-25ec-2365-8e57-4e7ec4f8f174",
+      "resource": {
+        "resourceType": "Medication",
+        "id": "da82c76b-25ec-2365-8e57-4e7ec4f8f174",
+        "code": {
+          "coding": [
+            {
+              "code": "248656",
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "display": "Azithromycin 500 MG Oral Tablet"
+            }
+          ]
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Medication/da82c76b-25ec-2365-8e57-4e7ec4f8f174"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:fe47f3c2-6f9a-0997-66b8-4584e3fecdc8",
+      "resource": {
+        "resourceType": "RelatedPerson",
+        "id": "fe47f3c2-6f9a-0997-66b8-4584e3fecdc8",
+        "relationship": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                "code": "GUARD",
+                "display": "Guardian"
+              }
+            ]
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "Mum",
+            "given": [
+              "Martha",
+              "L"
+            ]
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+1-555-555-2006",
+            "use": "home"
+          },
+          {
+            "system": "email",
+            "value": "mail@guardian.com"
+          }
+        ],
+        "address": [
+          {
+            "use": "home",
+            "line": [
+              "4444 Home Street"
+            ],
+            "city": "Ann Arbor",
+            "state": "MI",
+            "country": "US",
+            "postalCode": "99999"
+          }
+        ],
+        "patient": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "RelatedPerson/fe47f3c2-6f9a-0997-66b8-4584e3fecdc8"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:971025bd-d2cd-6731-e9f1-7d51fbeea207",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "971025bd-d2cd-6731-e9f1-7d51fbeea207",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-pregnancy-status-observation"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:bab77407-f76d-4a51-a2ed-980c8a59fe28"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "exam"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "82810-3",
+              "display": "Pregnancy status"
+            }
+          ]
+        },
+        "effectivePeriod": {
+          "start": "2017-08-26"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "77386006",
+              "system": "http://snomed.info/sct",
+              "display": "Pregnant"
+            }
+          ]
+        },
+        "method": {
+          "coding": [
+            {
+              "code": "16310003",
+              "system": "http://snomed.info/sct",
+              "display": "Diagnostic ultrasonography (procedure)"
+            }
+          ]
+        },
+        "component": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-date-determined-extension",
+                "valueDateTime": "2017-10-01T10:15:00"
+              }
+            ],
+            "code": {
+              "coding": [
+                {
+                  "code": "11780-4",
+                  "system": "http://loinc.org",
+                  "display": "Delivery date estimated from ovulation date"
+                }
+              ]
+            },
+            "valueDateTime": "2017-05-22"
+          },
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-date-determined-extension",
+                "valueDateTime": "2017-10-01T10:15:00"
+              }
+            ],
+            "code": {
+              "coding": [
+                {
+                  "code": "11887-7",
+                  "system": "http://loinc.org",
+                  "display": "Gestational age Estimated from selected delivery date"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 143,
+              "unit": "d"
+            }
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-date-recorded-extension",
+            "valueDateTime": "2017-10-01T10:35:00"
+          },
+          {
+            "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-date-determined-extension",
+            "valueDateTime": "2017-10-01"
+          }
+        ],
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/971025bd-d2cd-6731-e9f1-7d51fbeea207"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:c806bc5b-20bf-181a-f6b1-49d52983e243",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "c806bc5b-20bf-181a-f6b1-49d52983e243",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-pregnancy-outcome-observation"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:6df3e951-e6f8-441d-a298-d9d6d3f405db"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "exam"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "63893-2",
+              "display": "Outcome of pregnancy"
+            }
+          ]
+        },
+        "effectiveDateTime": "2018-01-05T08:50:00",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "237364002",
+              "system": "http://snomed.info/sct",
+              "display": "Stillbirth (finding)"
+            }
+          ]
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "73771-8",
+                  "display": "Birth order"
+                }
+              ]
+            },
+            "valueInteger": 1
+          }
+        ],
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        },
+        "focus": [
+          {
+            "reference": "Observation/971025bd-d2cd-6731-e9f1-7d51fbeea207"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/c806bc5b-20bf-181a-f6b1-49d52983e243"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:e918b73b-aad0-4797-3ee3-ff8b96d3a054",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "e918b73b-aad0-4797-3ee3-ff8b96d3a054",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Observation-last-menstrual-period"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:5ffea0ae-9ae5-4313-956a-30219b4a6afa"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "exam"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "8665-2",
+              "display": "Last menstrual period start date"
+            }
+          ]
+        },
+        "effectiveDateTime": "2018-01-05T10:15:00",
+        "valueDateTime": "2017-08-01",
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/e918b73b-aad0-4797-3ee3-ff8b96d3a054"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:4e7f8ad6-3b2a-91e0-0d2a-42f0b0d5719d",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "4e7f8ad6-3b2a-91e0-0d2a-42f0b0d5719d",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/2.1.2/StructureDefinition-us-ph-postpartum-status"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:9701b264-0f70-47f9-bfbf-aa4f9686cd3a"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "exam"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "249197004",
+              "display": "Maternal condition during puerperium (observable entity)"
+            }
+          ]
+        },
+        "effectiveDateTime": "2018-01-05T10:15:00",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "42814007",
+              "system": "http://snomed.info/sct",
+              "display": "Mid postpartum state (finding)"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/4e7f8ad6-3b2a-91e0-0d2a-42f0b0d5719d"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:0e598eaf-fad7-7fa4-1bb3-6f7dcf1e4543",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "0e598eaf-fad7-7fa4-1bb3-6f7dcf1e4543",
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:7d5a02b0-67a4-11db-bd13-0800200c9a66"
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "57021-8",
+              "system": "http://loinc.org",
+              "display": "CBC W Auto Differential panel in Blood"
+            }
+          ]
+        },
+        "effectivePeriod": {
+          "start": "2018-11-07",
+          "end": "2018-11-07"
+        },
+        "extension": [
+          {
+            "url": "http://terminology.hl7.org/CodeSystem/v2-0123",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "code": "F",
+                  "system": "urn:oid:2.16.840.1.113883.18.51",
+                  "display": "Final results; results stored and verified. Can only be changed with a corrected result."
+                }
+              ]
+            }
+          }
+        ],
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        },
+        "specimen": [
+          {
+            "reference": "Specimen/e9912a9e-f5c5-5324-64f5-09fb48c6f743"
+          }
+        ],
+        "result": [
+          {
+            "reference": "Observation/542cf409-a330-2185-6cfc-7f7f20d593c8"
+          },
+          {
+            "reference": "Observation/fe859df1-071e-3927-dcaa-9f511660a24d"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "DiagnosticReport/0e598eaf-fad7-7fa4-1bb3-6f7dcf1e4543"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:e9912a9e-f5c5-5324-64f5-09fb48c6f743",
+      "resource": {
+        "resourceType": "Specimen",
+        "id": "e9912a9e-f5c5-5324-64f5-09fb48c6f743",
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:44fd0410-6115-4b8e-8ee9-a51b3817df66"
+          }
+        ],
+        "type": {
+          "coding": [
+            {
+              "code": "119297000",
+              "system": "http://snomed.info/sct",
+              "display": "Blood specimen (specimen)"
+            }
+          ]
+        },
+        "collection": {
+          "collectedPeriod": {
+            "start": "2018-03-09"
+          },
+          "bodySite": {
+            "coding": [
+              {
+                "code": "368208006",
+                "system": "http://snomed.info/sct",
+                "display": "Left upper arm structure (body structure)"
+              }
+            ]
+          }
+        },
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Specimen/e9912a9e-f5c5-5324-64f5-09fb48c6f743"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:542cf409-a330-2185-6cfc-7f7f20d593c8",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "542cf409-a330-2185-6cfc-7f7f20d593c8",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-lab-result-observation"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:7c0704bb-9c40-41b5-9c7d-26b2d59e234f"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "20570-8",
+              "system": "http://loinc.org",
+              "display": "Hematocrit"
+            }
+          ]
+        },
+        "effectiveDateTime": "2018-11-07",
+        "valueQuantity": {
+          "value": 35.3,
+          "unit": "%"
+        },
+        "referenceRange": [
+          {
+            "text": "34.9 % - 44.5 %",
+            "low": {
+              "value": 34.9,
+              "unit": "%"
+            },
+            "high": {
+              "value": 44.5,
+              "unit": "%"
+            },
+            "type": {
+              "coding": [
+                {
+                  "code": "L",
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                  "display": "Low"
+                }
+              ]
+            }
+          }
+        ],
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "code": "L",
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "display": "Low"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/542cf409-a330-2185-6cfc-7f7f20d593c8"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:fe859df1-071e-3927-dcaa-9f511660a24d",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "fe859df1-071e-3927-dcaa-9f511660a24d",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-lab-result-observation"
+          ]
+        },
+        "identifier": [
+          {
+            "value": "7c0704bb-9c40-41b5-9c7d-26b2d59e234g"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "731-0",
+              "system": "http://loinc.org",
+              "display": "Lymphocytes [#/​volume] in Blood by Automated count"
+            }
+          ]
+        },
+        "effectiveDateTime": "2018-11-07",
+        "valueQuantity": {
+          "value": 5.2,
+          "unit": "10*3/uL"
+        },
+        "referenceRange": [
+          {
+            "text": "1.0 10*3/uL - 4.8 10*3/uL",
+            "low": {
+              "value": 1.0,
+              "unit": "10*3/uL"
+            },
+            "high": {
+              "value": 4.8,
+              "unit": "10*3/uL"
+            },
+            "type": {
+              "coding": [
+                {
+                  "code": "N",
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                  "display": "Normal"
+                }
+              ]
+            }
+          }
+        ],
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "code": "H",
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "display": "High"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/fe859df1-071e-3927-dcaa-9f511660a24d"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:1ff11a5a-bb04-839b-f590-fb53f3aac6cf",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "1ff11a5a-bb04-839b-f590-fb53f3aac6cf",
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:a4307cb2-b3b4-4f42-be03-1d9077376f4a"
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "11585-7",
+              "system": "http://loinc.org",
+              "display": "Bordetella pertussis Ab [Units/volume] in Serum"
+            }
+          ]
+        },
+        "effectivePeriod": {
+          "start": "2018-11-07",
+          "end": "2018-11-07"
+        },
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        },
+        "result": [
+          {
+            "reference": "Observation/6235785d-3468-42dc-8c76-d4c70d67f2e9"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "DiagnosticReport/1ff11a5a-bb04-839b-f590-fb53f3aac6cf"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:6235785d-3468-42dc-8c76-d4c70d67f2e9",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "6235785d-3468-42dc-8c76-d4c70d67f2e9",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-lab-result-observation"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:bf9c0a26-4524-4395-b3ce-100450b9c9ad"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "11585-7",
+              "system": "http://loinc.org",
+              "display": "Bordetella pertussis Ab [Units/volume] in Serum"
+            }
+          ]
+        },
+        "effectiveDateTime": "2018-11-07",
+        "valueQuantity": {
+          "value": 100,
+          "unit": "[iU]/mL"
+        },
+        "referenceRange": [
+          {
+            "high": {
+              "value": 45,
+              "unit": "[iU]/mL"
+            },
+            "type": {
+              "coding": [
+                {
+                  "code": "N",
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                  "display": "Normal"
+                }
+              ]
+            }
+          }
+        ],
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "code": "H",
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "display": "High"
+              }
+            ]
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://terminology.hl7.org/ValueSet/v2-0085",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "code": "F",
+                  "system": "urn:oid:2.16.840.1.113883.18.34",
+                  "display": "Final results"
+                }
+              ]
+            }
+          }
+        ],
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/6235785d-3468-42dc-8c76-d4c70d67f2e9"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:fdd7fe34-d9fc-3ab8-87c0-a754a19175c7",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "fdd7fe34-d9fc-3ab8-87c0-a754a19175c7",
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:a4307cb2-b3b4-4f42-be03-1d9077376f4b"
+          }
+        ],
+        "status": "preliminary",
+        "code": {
+          "coding": [
+            {
+              "code": "548-8",
+              "system": "http://loinc.org",
+              "display": "Bordetella pertussis [Presence] in Throat by Organism specific culture"
+            }
+          ]
+        },
+        "effectivePeriod": {
+          "start": "2018-11-07",
+          "end": "2018-11-07"
+        },
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        },
+        "result": [
+          {
+            "reference": "Observation/145a35c6-8d22-9a2c-a1f9-2962a6586b3e"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "DiagnosticReport/fdd7fe34-d9fc-3ab8-87c0-a754a19175c7"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:145a35c6-8d22-9a2c-a1f9-2962a6586b3e",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "145a35c6-8d22-9a2c-a1f9-2962a6586b3e",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-lab-result-observation"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:bf9c0a26-4524-4395-b3ce-100450b9c9ac"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "status": "preliminary",
+        "code": {
+          "coding": [
+            {
+              "code": "local_code_pertussis",
+              "system": "urn:oid:2.16.840.1.113883.1.2.3.665",
+              "display": "Bordetella pertussis in Throat by Organism specific culture"
+            },
+            {
+              "code": "548-8",
+              "system": "http://loinc.org",
+              "display": "Bordetella pertussis [Presence] in Throat by Organism specific culture"
+            }
+          ]
+        },
+        "effectiveDateTime": "2018-11-07",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "5247005",
+              "system": "http://snomed.info/sct",
+              "display": "Bordetella pertussis (organism)"
+            }
+          ]
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "code": "A",
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "display": "Abnormal"
+              }
+            ]
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://terminology.hl7.org/ValueSet/v2-0085",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "code": "P",
+                  "system": "urn:oid:2.16.840.1.113883.18.34",
+                  "display": "Preliminary results"
+                }
+              ]
+            }
+          }
+        ],
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/145a35c6-8d22-9a2c-a1f9-2962a6586b3e"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:32076aed-d020-9b44-d756-327a72167578",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "32076aed-d020-9b44-d756-327a72167578",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-characteristics-of-home-environment"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:37f76c51-6411-4e1d-8a37-957fd49d2ced"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "75274-1",
+              "system": "http://loinc.org",
+              "display": "Characteristics of residence"
+            }
+          ]
+        },
+        "effectiveDateTime": "2018-11-09",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "32911000",
+              "system": "http://snomed.info/sct",
+              "display": "Homeless (finding)"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/32076aed-d020-9b44-d756-327a72167578"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:41fb62f4-0827-2a1a-c85e-afc77b2c92d5",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "41fb62f4-0827-2a1a-c85e-afc77b2c92d5",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-travel-history"
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "420008001",
+              "display": "Travel"
+            }
+          ],
+          "text": "Travel History"
+        },
+        "status": "final",
+        "effectivePeriod": {
+          "start": "1999",
+          "end": "2007"
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                  "code": "LOC",
+                  "display": "Location"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "text": "Spent 8 years in the UK during the BSE outbreak"
+            }
+          }
+        ],
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/41fb62f4-0827-2a1a-c85e-afc77b2c92d5"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:e419541c-79fc-a50e-6c78-f93b7715fc88",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "e419541c-79fc-a50e-6c78-f93b7715fc88",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-travel-history"
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "420008001",
+              "display": "Travel"
+            }
+          ],
+          "text": "Travel History"
+        },
+        "status": "final",
+        "effectivePeriod": {
+          "start": "2018-10-19",
+          "end": "2018-11-09"
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                  "code": "LOC",
+                  "display": "Location"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "code": "BRA",
+                  "system": "urn:oid:1.0.3166.1",
+                  "display": "Brazil"
+                }
+              ]
+            }
+          }
+        ],
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/e419541c-79fc-a50e-6c78-f93b7715fc88"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:d5b5f6ce-cd21-c9a0-5778-e5276364c153",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "d5b5f6ce-cd21-c9a0-5778-e5276364c153",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-travel-history"
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "420008001",
+              "display": "Travel"
+            }
+          ],
+          "text": "Travel History"
+        },
+        "status": "final",
+        "effectivePeriod": {
+          "start": "2018-04-25",
+          "end": "2018-04-30"
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                  "code": "LOC",
+                  "display": "Location"
+                }
+              ]
+            },
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-address-extension",
+                "valueAddress": {
+                  "city": "Nadi",
+                  "country": "FJ"
+                }
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/d5b5f6ce-cd21-c9a0-5778-e5276364c153"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:e0b83dcd-dced-1a38-d82a-eca78198428b",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "e0b83dcd-dced-1a38-d82a-eca78198428b",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-travel-history"
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "420008001",
+              "display": "Travel"
+            }
+          ],
+          "text": "Travel History"
+        },
+        "status": "final",
+        "effectivePeriod": {
+          "start": "2018-05-06",
+          "end": "2018-05-15"
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                  "code": "LOC",
+                  "display": "Location"
+                }
+              ]
+            },
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-address-extension",
+                "valueAddress": {
+                  "city": "Montreal",
+                  "state": "QC",
+                  "country": "CA"
+                }
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/e0b83dcd-dced-1a38-d82a-eca78198428b"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:8b536f6b-b441-948d-764c-517fa4869ddd",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "8b536f6b-b441-948d-764c-517fa4869ddd",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-travel-history"
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "420008001",
+              "display": "Travel"
+            }
+          ],
+          "text": "Travel History"
+        },
+        "status": "final",
+        "effectivePeriod": {
+          "start": "2018-07-13",
+          "end": "2018-07-15"
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                  "code": "LOC",
+                  "display": "Location"
+                }
+              ]
+            },
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-address-extension",
+                "valueAddress": {
+                  "city": "Sydney",
+                  "state": "NSW",
+                  "country": "AU"
+                }
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/8b536f6b-b441-948d-764c-517fa4869ddd"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:8a65af49-3816-ab97-1179-3ebe9c728122",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "8a65af49-3816-ab97-1179-3ebe9c728122",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-travel-history"
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "420008001",
+              "display": "Travel"
+            }
+          ],
+          "text": "Travel History"
+        },
+        "status": "final",
+        "effectivePeriod": {
+          "start": "2018-10-22",
+          "end": "2018-10-30"
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                  "code": "LOC",
+                  "display": "Location"
+                }
+              ]
+            },
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-address-extension",
+                "valueAddress": {
+                  "line": [
+                    "1170 N Rancho Robles Rd"
+                  ],
+                  "city": "Oracle",
+                  "state": "AZ",
+                  "country": "US",
+                  "postalCode": "8562"
+                }
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/8a65af49-3816-ab97-1179-3ebe9c728122"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:6770d2f8-c964-aac6-b8c2-df22bba56b7a",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "6770d2f8-c964-aac6-b8c2-df22bba56b7a",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/odh/StructureDefinition/odh-UsualWork"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:4f4b3876-8570-41a0-b995-cf34f37c5cbf"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "21843-8",
+              "system": "http://loinc.org",
+              "display": "Usual Occupation"
+            }
+          ]
+        },
+        "effectivePeriod": {
+          "start": "1996-11-24"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "1200",
+              "system": "urn:oid:2.16.840.1.114222.4.5.314",
+              "display": "Actuaries"
+            }
+          ]
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "21844-6",
+                  "system": "http://loinc.org",
+                  "display": "Usual Industry"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "code": "7280",
+                  "system": "urn:oid:2.16.840.1.114222.4.5.315",
+                  "display": "Accounting, tax preparation, bookkeeping, and payroll services"
+                }
+              ]
+            }
+          }
+        ],
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/6770d2f8-c964-aac6-b8c2-df22bba56b7a"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:f8a425b4-e7da-6c88-64ed-07d776377c11",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "f8a425b4-e7da-6c88-64ed-07d776377c11",
+        "identifier": [
+          {
+            "system": "urn:uuid:58822180-ab0d-42e4-90c6-35336bf55654",
+            "value": "12345"
+          }
+        ],
+        "name": "CDC",
+        "address": [
+          {
+            "line": [
+              "Peachtree St"
+            ],
+            "city": "Ann Arbor",
+            "state": "Georgia"
+          }
+        ],
+        "telecom": [
+          {
+            "value": "555-1212",
+            "use": "work"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/f8a425b4-e7da-6c88-64ed-07d776377c11"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Observation",
+        "id": "033923b6-9c24-956e-21c2-b8e2478bc446",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/odh/StructureDefinition/odh-Employer-extension",
+            "valueReference": {
+              "reference": "Organization/f8a425b4-e7da-6c88-64ed-07d776377c11"
+            }
+          }
+        ],
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/odh/StructureDefinition/odh-PastOrPresentJob"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:1728123a-7b6c-418c-adc2-f78417caf62c"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "unknown",
+        "code": {
+          "coding": [
+            {
+              "code": "11341-5",
+              "system": "http://loinc.org",
+              "display": "History of Occupation"
+            }
+          ]
+        },
+        "effectivePeriod": {
+          "start": "2015-04-24"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "1200",
+              "system": "urn:oid:2.16.840.1.114222.4.5.314",
+              "display": "Actuaries"
+            }
+          ]
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "87729-0",
+                  "system": "http://loinc.org",
+                  "display": "History of Occupational hazard"
+                }
+              ]
+            },
+            "valueString": "Asbestos"
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "86188-0",
+                  "system": "http://loinc.org",
+                  "display": "Occupation Industry"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "code": "7280",
+                  "system": "urn:oid:2.16.840.1.114222.4.5.315",
+                  "display": "Accounting, tax preparation, bookkeeping, and payroll services"
+                }
+              ]
+            }
+          }
+        ],
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "fullUrl": "urn:uuid:033923b6-9c24-956e-21c2-b8e2478bc446",
+      "request": {
+        "method": "PUT",
+        "url": "Observation/033923b6-9c24-956e-21c2-b8e2478bc446"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:5f8639bd-0579-7698-6ade-9555cfe2bdff",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "5f8639bd-0579-7698-6ade-9555cfe2bdff",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:2721acc5-0d05-4402-9e62-79943ea3901c"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "8480-6",
+              "system": "http://loinc.org",
+              "display": "SYSTOLIC BLOOD PRESSURE"
+            }
+          ]
+        },
+        "effectiveDateTime": "2014-05-20T19:36:05-05:00",
+        "valueQuantity": {
+          "value": 120,
+          "unit": "mm[Hg]"
+        },
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/5f8639bd-0579-7698-6ade-9555cfe2bdff"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:8e60fc3c-0790-08ce-da9b-4da0bb028115",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "8e60fc3c-0790-08ce-da9b-4da0bb028115",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:88a01c83-a096-4705-a992-b5f59eca8c8c"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "8462-4",
+              "system": "http://loinc.org",
+              "display": "DIASTOLIC BLOOD PRESSURE"
+            }
+          ]
+        },
+        "effectiveDateTime": "2014-05-20T19:36:05-05:00",
+        "valueQuantity": {
+          "value": 80,
+          "unit": "mm[Hg]"
+        },
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/8e60fc3c-0790-08ce-da9b-4da0bb028115"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:c553f18d-9df3-590b-5900-acf75899ec21",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "c553f18d-9df3-590b-5900-acf75899ec21",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:83bbffe1-54e5-4984-a32d-ad8f8d6896d8"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "8867-4",
+              "system": "http://loinc.org",
+              "display": "HEART RATE"
+            }
+          ]
+        },
+        "effectiveDateTime": "2014-05-20T19:36:05-05:00",
+        "valueQuantity": {
+          "value": 80,
+          "unit": "/min"
+        },
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/c553f18d-9df3-590b-5900-acf75899ec21"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:08747908-0c7e-9928-913d-65d7243d9487",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "08747908-0c7e-9928-913d-65d7243d9487",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:85f5784f-2958-4321-b7b6-3030d1577dc0"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "8310-5",
+              "system": "http://loinc.org",
+              "display": "BODY TEMPERATURE"
+            }
+          ]
+        },
+        "effectiveDateTime": "2014-05-20T19:36:05-05:00",
+        "valueQuantity": {
+          "value": 99.0,
+          "unit": "[degF]"
+        },
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/08747908-0c7e-9928-913d-65d7243d9487"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:fb26676b-06f1-676c-acb2-458126dc6535",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "fb26676b-06f1-676c-acb2-458126dc6535",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:b618fa98-6596-4e19-a9e7-6bdb48012fc8"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "9279-1",
+              "system": "http://loinc.org",
+              "display": "RESPIRATORY RATE"
+            }
+          ]
+        },
+        "effectiveDateTime": "2014-05-20T19:36:05-05:00",
+        "valueQuantity": {
+          "value": 18,
+          "unit": "/min"
+        },
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/fb26676b-06f1-676c-acb2-458126dc6535"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:a7226ec7-2e47-136b-c464-9ae6552f0a15",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "a7226ec7-2e47-136b-c464-9ae6552f0a15",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:1b1274a9-b45f-449a-8493-08eaeaeba7d6"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "8302-2",
+              "system": "http://loinc.org",
+              "display": "HEIGHT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2014-05-20T19:36:05-05:00",
+        "valueQuantity": {
+          "value": 67,
+          "unit": "[in_us]"
+        },
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/a7226ec7-2e47-136b-c464-9ae6552f0a15"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:38c6218f-8693-d40d-f1ce-5d345f32a553",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "38c6218f-8693-d40d-f1ce-5d345f32a553",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:1c1f89f1-8e93-4a46-b37f-9434f99727b8"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "3141-9",
+              "system": "http://loinc.org",
+              "display": "WEIGHT"
+            }
+          ]
+        },
+        "effectiveDateTime": "2014-05-20T19:36:05-05:00",
+        "valueQuantity": {
+          "value": 239.9,
+          "unit": "[lb_av]"
+        },
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/38c6218f-8693-d40d-f1ce-5d345f32a553"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:16e91e0a-8e11-7635-f67a-f0cc88395e8d",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "16e91e0a-8e11-7635-f67a-f0cc88395e8d",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:fd4ccd0b-c045-4587-8976-a17e2e064a1e"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "39156-5",
+              "system": "http://loinc.org",
+              "display": "BODY MASS INDEX"
+            }
+          ]
+        },
+        "effectiveDateTime": "2014-05-20T19:36:05-05:00",
+        "valueQuantity": {
+          "value": 37.58,
+          "unit": "kg/m2"
+        },
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/16e91e0a-8e11-7635-f67a-f0cc88395e8d"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:5a2fdf42-c9cd-7938-6f1e-faceebac6f1c",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "5a2fdf42-c9cd-7938-6f1e-faceebac6f1c",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:0ef4afda-1638-4ad2-9978-7321bbceb0cb"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "2710-2",
+              "system": "http://loinc.org",
+              "display": "OXYGEN SATURATION"
+            }
+          ]
+        },
+        "effectiveDateTime": "2014-05-20T19:36:05-05:00",
+        "valueQuantity": {
+          "value": 98,
+          "unit": "%"
+        },
+        "subject": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/5a2fdf42-c9cd-7938-6f1e-faceebac6f1c"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:007787d7-b7e4-26af-fba4-1ce1f439a903",
+      "resource": {
+        "resourceType": "Immunization",
+        "id": "007787d7-b7e4-26af-fba4-1ce1f439a903",
+        "identifier": [
+          {
+            "system": "urn:uuid:00000000-5cf3-ec63-0513-4a4838595787",
+            "value": "11369-6_3-1_1.3.6.1.4.1.22812.11.2016.163.1_14168"
+          }
+        ],
+        "occurrenceDateTime": "2018-11-07",
+        "vaccineCode": {
+          "coding": [
+            {
+              "code": "106",
+              "system": "urn:oid:2.16.840.1.113883.12.292",
+              "display": "diphtheria, tetanus toxoids and acellular pertussis vaccine, 5 pertussis antigens"
+            }
+          ]
+        },
+        "status": "completed",
+        "primarySource": true,
+        "patient": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Immunization/007787d7-b7e4-26af-fba4-1ce1f439a903"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:3a0ef01d-9da9-63dc-e03b-bdffa3ee0b1d",
+      "resource": {
+        "resourceType": "Immunization",
+        "id": "3a0ef01d-9da9-63dc-e03b-bdffa3ee0b1d",
+        "identifier": [
+          {
+            "system": "urn:uuid:00000000-5cf3-ec63-0513-4a4838595787",
+            "value": "11369-6_2-1_1.3.6.1.4.1.22812.11.2016.163.1_14168"
+          }
+        ],
+        "occurrenceDateTime": "2018-11-07",
+        "vaccineCode": {
+          "coding": [
+            {
+              "code": "88",
+              "system": "urn:oid:2.16.840.1.113883.12.292",
+              "display": "influenza virus vaccine, unspecified formulation"
+            }
+          ]
+        },
+        "status": "completed",
+        "primarySource": true,
+        "patient": {
+          "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Immunization/3a0ef01d-9da9-63dc-e03b-bdffa3ee0b1d"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Substance admionistrations can have multiple effective times. This is because typically one will be a period that a medication should be taken, and the other will be a frequency for how often a medication should be taken within the period. Typically these can be differentiated by the frequency will have the attribute `operator="A"`. However within the eICRS found in the XML Harvester repo. There is a substance administration with only one effective time with `operator="A"` and a value. Therefore it should be safe that this is actual just a point in time. 