### PR TITLE
fix: escape special characters in addresses

### DIFF
--- a/data/Templates/eCR/DataType/Address.liquid
+++ b/data/Templates/eCR/DataType/Address.liquid
@@ -7,10 +7,10 @@
             "{{ l._ | clean_string_from_tabs | escape_special_chars }}",
         {%- endfor -%}
     ],
-    "city": "{{Address.city._}}",
-    "state": "{{Address.state._}}",
-    "country": "{{Address.country._}}",
-    "postalCode": "{{Address.postalCode._}}",
-    "district": "{{Address.county._}}",
+    "city": "{{Address.city._ | escape_special_chars}}",
+    "state": "{{Address.state._ | escape_special_chars}}",
+    "country": "{{Address.country._ | escape_special_chars}}",
+    "postalCode": "{{Address.postalCode._ | escape_special_chars}}",
+    "district": "{{Address.county._ | escape_special_chars}}",
     "period": { {% include 'DataType/Period', Period: Address.useablePeriod %} },
 {% endif -%}

--- a/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/DataType/AddressTests.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/DataType/AddressTests.cs
@@ -124,6 +124,34 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests
                 @"""use"": """", ""line"": [], ""city"": """", ""state"": """", ""country"": ""Country"", ""postalCode"": """", ""district"": """", ""period"": { ""start"":""2024-03-13"", ""end"":"""", },");
         }
 
+        [Fact]
+        public async System.Threading.Tasks.Task EscapesSpecialChars()
+        {
+            var attributes = new Dictionary<string, object>{
+                {"Address", 
+                    new { 
+                        streetAddressLine = new [] { 
+                            new {_ = @"Li\ne1" }, 
+                            new { _ = @"""Line2""" }
+                        }, 
+                        city = new {_ = "/" },
+                        state = new {_ = @"\" },
+                        country = new {_ = "\"\"" },
+                        postalCode = new {_ = "[12345]" },
+                        county = new {_ = @"Dis\trict" },
+                        useablePeriod = new { 
+                            low = new { value = "20240313"}
+                        } 
+                    }
+                }
+            };
+
+            await ConvertCheckLiquidTemplate(
+                ECRPath, 
+                attributes, 
+                @"""use"": """", ""line"": [""Li\\ne1"",""\""Line2\"""",], ""city"": ""/"", ""state"": ""\\"", ""country"": ""\""\"""", ""postalCode"": ""[12345]"", ""district"": ""Dis\\trict"", ""period"": { ""start"":""2024-03-13"", ""end"":"""", },");
+        }
+
     }
    
 }


### PR DESCRIPTION
# PULL REQUEST

_PR title: Remember to name your PR descriptively and follow [conventional commits](https://cheatsheets.zip/conventional-commits)!_

## Summary

Escapes special characters in address fields to prevent conversion failures.

## Related Issue

Fixes #1349

## Acceptance Criteria

- [ ] City, state, country, postal code, and district should have special characters escaped
- [ ] Any relevant unit/snapshot tests should be added.

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] ⚠️ Create an associated `dibbs-ecr-viewer` PR & checked that things work on the front-end.
- [ ] If necessary, update any test fixtures/bundles to reflect FHIR conversion changes (in this repo and/or `dibbs-ecr-viewer`)
- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

⚠️ Do not merge this PR until the associated `dibbs-ecr-viewer` PR is created and validated. When both have been approved:
1. Merge the FHIR converter PR
2. Cut a new release of `dibbs-fhir-converter`
3. Update the [fhir-converter Dockerfile](https://github.com/CDCgov/dibbs-ecr-viewer/blob/main/containers/fhir-converter/Dockerfile) in `dibbs-ecr-viewer` with the updated release branch number.