### PR TITLE
fix: properly handle value quantities that contain non-numeric characters

### DIFF
--- a/data/Templates/eCR/Header.liquid
+++ b/data/Templates/eCR/Header.liquid
@@ -1,5 +1,4 @@
 {% assign compositionId = msg.ClinicalDocument | to_json_string | generate_uuid -%}
-{% assign doof = msg.doof %}
 {% evaluate practitionerId using 'Utils/GenerateId' obj: msg.ClinicalDocument.componentOf.encompassingEncounter.responsibleParty.assignedEntity -%}
 {% include 'Resource/Composition', composition: msg.ClinicalDocument, practitionerId: practitionerId, ID: compositionId -%}
 {% include 'Reference/Composition/Subject', ID: compositionId, REF: fullPatientId -%}

--- a/data/Templates/eCR/Utils/ValueHelper.liquid
+++ b/data/Templates/eCR/Utils/ValueHelper.liquid
@@ -13,12 +13,8 @@
             {% assign formattedDecimal = value.value | format_decimal %}
             {% if formattedDecimal != nil %}
                 {{ formattedDecimal | escape_special_chars }},
-            {% comment %} {% elsif value.value startswith "." %}
-                {{ "0" | append: value.value | escape_special_chars }},
             {% else %}
-                {{ value.value | escape_special_chars }}, {% endcomment %}
-            {% else %}
-                "{{value.value | escape_special_chars}}"
+                "{{value.value | escape_special_chars}}",
             {% endif %}
         {% endif %}
         {% if value.unit and value.unit != "null" -%}

--- a/data/Templates/eCR/Utils/ValueHelper.liquid
+++ b/data/Templates/eCR/Utils/ValueHelper.liquid
@@ -9,16 +9,15 @@
 {% elsif value.value -%}
     "valueQuantity": {
         {% if value.value != blank %}
-        "value":
-            {% assign formattedDecimal = value.value | format_decimal %}
-            {% if formattedDecimal != nil %}
-                {{ formattedDecimal | escape_special_chars }},
-            {% else %}
-                "{{value.value | escape_special_chars}}",
-            {% endif %}
+            "value": {{ value.value | format_valuequantity }},
         {% endif %}
         {% if value.unit and value.unit != "null" -%}
-            "unit":"{{ value.unit }}",
+            "unit":"{{ value.unit | escape_special_chars }}",
+        {% else %}
+            {% assign unitFromValue = value.value | extract_unit %}
+            {% if unitFromValue != nil %}
+                "unit":"{{ unitFromValue | escape_special_chars }}",
+            {% endif -%}
         {% endif -%}
     },
 {% elsif value._ %}

--- a/data/Templates/eCR/Utils/ValueHelper.liquid
+++ b/data/Templates/eCR/Utils/ValueHelper.liquid
@@ -10,10 +10,15 @@
     "valueQuantity": {
         {% if value.value != blank %}
         "value":
-            {% if value.value startswith "." %}
+            {% assign formattedDecimal = value.value | format_decimal %}
+            {% if formattedDecimal != nil %}
+                {{ formattedDecimal | escape_special_chars }},
+            {% comment %} {% elsif value.value startswith "." %}
                 {{ "0" | append: value.value | escape_special_chars }},
             {% else %}
-                {{ value.value | escape_special_chars }},
+                {{ value.value | escape_special_chars }}, {% endcomment %}
+            {% else %}
+                "{{value.value | escape_special_chars}}"
             {% endif %}
         {% endif %}
         {% if value.unit and value.unit != "null" -%}

--- a/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Filters/GeneralFiltersTests.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Filters/GeneralFiltersTests.cs
@@ -163,5 +163,17 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests.FilterTests
 
             Assert.Equal(expected, Filters.RemovePrefix(StringValue.Create(extension), new FilterArguments(StringValue.Create(root)), context).Result.ToStringValue());
         }
+
+        [Fact]
+        public void FormatDecimal()
+        {
+            var context = new TemplateContext();
+
+            Assert.Equal("0.29", Filters.FormatDecimal(StringValue.Create(".29"), FilterArguments.Empty, context).Result.ToStringValue());
+            Assert.Equal("300", Filters.FormatDecimal(StringValue.Create("300"), FilterArguments.Empty, context).Result.ToStringValue());
+            Assert.True(Filters.FormatDecimal(StringValue.Create(".50 in"), FilterArguments.Empty, context).Result.IsNil());
+            Assert.Equal("300.00", Filters.FormatDecimal(StringValue.Create("300.00"), FilterArguments.Empty, context).Result.ToStringValue());
+            Assert.Equal("-300", Filters.FormatDecimal(StringValue.Create("-300"), FilterArguments.Empty, context).Result.ToStringValue());
+        }
     }
 }

--- a/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Filters/GeneralFiltersTests.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Filters/GeneralFiltersTests.cs
@@ -165,15 +165,25 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests.FilterTests
         }
 
         [Fact]
-        public void FormatDecimal()
+        public void FormatValueQuantity()
         {
             var context = new TemplateContext();
 
-            Assert.Equal("0.29", Filters.FormatDecimal(StringValue.Create(".29"), FilterArguments.Empty, context).Result.ToStringValue());
-            Assert.Equal("300", Filters.FormatDecimal(StringValue.Create("300"), FilterArguments.Empty, context).Result.ToStringValue());
-            Assert.True(Filters.FormatDecimal(StringValue.Create(".50 in"), FilterArguments.Empty, context).Result.IsNil());
-            Assert.Equal("300.00", Filters.FormatDecimal(StringValue.Create("300.00"), FilterArguments.Empty, context).Result.ToStringValue());
-            Assert.Equal("-300", Filters.FormatDecimal(StringValue.Create("-300"), FilterArguments.Empty, context).Result.ToStringValue());
+            Assert.Equal("0.29", Filters.FormatValueQuantity(StringValue.Create(".29"), FilterArguments.Empty, context).Result.ToStringValue());
+            Assert.Equal("300", Filters.FormatValueQuantity(StringValue.Create("300"), FilterArguments.Empty, context).Result.ToStringValue());
+            Assert.True(Filters.FormatValueQuantity(StringValue.Create(".50 in"), FilterArguments.Empty, context).Result.IsNil());
+            Assert.Equal("300.00", Filters.FormatValueQuantity(StringValue.Create("300.00"), FilterArguments.Empty, context).Result.ToStringValue());
+            Assert.Equal("-300", Filters.FormatValueQuantity(StringValue.Create("-300"), FilterArguments.Empty, context).Result.ToStringValue());
+        }
+
+        [Fact]
+        public void ExtractUnit()
+        {
+            var context = new TemplateContext();
+
+            Assert.Equal("in", Filters.ExtractUnit(StringValue.Create("12 in"), FilterArguments.Empty, context).Result.ToStringValue());
+            Assert.Equal("$", Filters.ExtractUnit(StringValue.Create("$1"), FilterArguments.Empty, context).Result.ToStringValue());
+            Assert.True(Filters.ExtractUnit(StringValue.Create("1"), FilterArguments.Empty, context).Result.IsNil());
         }
     }
 }

--- a/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Filters/GeneralFiltersTests.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Filters/GeneralFiltersTests.cs
@@ -171,9 +171,10 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests.FilterTests
 
             Assert.Equal("0.29", Filters.FormatValueQuantity(StringValue.Create(".29"), FilterArguments.Empty, context).Result.ToStringValue());
             Assert.Equal("300", Filters.FormatValueQuantity(StringValue.Create("300"), FilterArguments.Empty, context).Result.ToStringValue());
-            Assert.True(Filters.FormatValueQuantity(StringValue.Create(".50 in"), FilterArguments.Empty, context).Result.IsNil());
+            Assert.Equal("0.50", Filters.FormatValueQuantity(StringValue.Create(".50 in"), FilterArguments.Empty, context).Result.ToStringValue());
             Assert.Equal("300.00", Filters.FormatValueQuantity(StringValue.Create("300.00"), FilterArguments.Empty, context).Result.ToStringValue());
             Assert.Equal("-300", Filters.FormatValueQuantity(StringValue.Create("-300"), FilterArguments.Empty, context).Result.ToStringValue());
+            Assert.True(Filters.FormatValueQuantity(StringValue.Create("in"), FilterArguments.Empty, context).Result.IsNil());
         }
 
         [Fact]

--- a/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Utils/ValueHelperTests.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Utils/ValueHelperTests.cs
@@ -11,63 +11,72 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests
         );
 
         [Fact]
-        public void GivenNoAttributeReturnsEmpty()
+        public async System.Threading.Tasks.Task GivenNoAttributeReturnsEmpty()
         {
-            ConvertCheckLiquidTemplate(ECRPath, new Dictionary<string, object>(), "\"valueString\":\"\",");
+            await ConvertCheckLiquidTemplate(ECRPath, new Dictionary<string, object>(), "\"valueString\":\"\",");
         }
 
         [Fact]
-        public void GivenDecimalProperlyReturnsWithDecimal()
+        public async System.Threading.Tasks.Task GivenDecimalProperlyReturnsWithDecimal()
         {
             var attributes = new Dictionary<string, object>{
                 {"value", new { value = ".29"}}
             };
-            ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": 0.29, },");
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": 0.29, },");
         }
 
         [Fact]
-        public void GivenIntProperlyReturnsInt()
+        public async System.Threading.Tasks.Task GivenIntProperlyReturnsInt()
         {
             var attributes = new Dictionary<string, object>{
                 {"value", new { value = "300"}}
             };
-            ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": 300, },");
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": 300, },");
         }
 
         [Fact]
-        public void GivenDecimalProperlyReturnsDecimal()
+        public async System.Threading.Tasks.Task GivenStringProperlyReturnsString()
+        {
+            var attributes = new Dictionary<string, object>{
+                {"value", new { value = ".50 in"}}
+            };
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": \".50 in\" },");
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task GivenDecimalProperlyReturnsDecimal()
         {
             var attributes = new Dictionary<string, object>{
                 {"value", new { value = "300.00"}}
             };
-            ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": 300.00, },");
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": 300.00, },");
         }
 
         [Fact]
-        public void GivenNegativeValueProperlyReturnsNegativeValue()
+        public async System.Threading.Tasks.Task GivenNegativeValueProperlyReturnsNegativeValue()
         {
             var attributes = new Dictionary<string, object>{
                 {"value", new { value = "-300.00"}}
             };
-            ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": -300.00, },");
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": -300.00, },");
         }
 
         [Fact]
-        public void GivenValueUnitProperlyReturnsWithValueUnit()
+        public async System.Threading.Tasks.Task GivenValueUnitProperlyReturnsWithValueUnit()
         {
             var attributes = new Dictionary<string, object>{
                 {"value", new { value = ".29" , unit = "/d"}}
             };
-            ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": 0.29, \"unit\":\"/d\", },");
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": 0.29, \"unit\":\"/d\", },");
         }
 
         [Fact]
-        public void GivenNoValueOnlyUnitProperlyReturnsUnit()
+        public async System.Threading.Tasks.Task GivenNoValueOnlyUnitProperlyReturnsUnit()
         {
             var attributes = new Dictionary<string, object>{
                 {"value", new { value = "" , unit = "Immediate"}}
             };
-            ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"unit\":\"Immediate\", },");
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"unit\":\"Immediate\", },");
         }
     }
 }

--- a/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Utils/ValueHelperTests.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Utils/ValueHelperTests.cs
@@ -40,7 +40,7 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests
             var attributes = new Dictionary<string, object>{
                 {"value", new { value = ".50 in"}}
             };
-            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": \".50 in\" },");
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": \".50 in\", },");
         }
 
         [Fact]

--- a/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Utils/ValueHelperTests.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Utils/ValueHelperTests.cs
@@ -62,6 +62,24 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests
         }
 
         [Fact]
+        public async System.Threading.Tasks.Task GivenZeroProperlyReturnsZero()
+        {
+            var attributes = new Dictionary<string, object>{
+                {"value", new { value = "0"}}
+            };
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": 0, },");
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task GivenZeroDecimalProperlyReturnsZeroDecimal()
+        {
+            var attributes = new Dictionary<string, object>{
+                {"value", new { value = "0.0"}}
+            };
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": 0.0, },");
+        }
+
+        [Fact]
         public async System.Threading.Tasks.Task GivenValueUnitProperlyReturnsWithValueUnit()
         {
             var attributes = new Dictionary<string, object>{

--- a/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Utils/ValueHelperTests.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Utils/ValueHelperTests.cs
@@ -35,12 +35,21 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests
         }
 
         [Fact]
-        public async System.Threading.Tasks.Task GivenStringProperlyReturnsString()
+        public async System.Threading.Tasks.Task GivenStringProperlyReturnsDecimal()
         {
             var attributes = new Dictionary<string, object>{
                 {"value", new { value = ".50 in"}}
             };
-            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": \".50 in\", },");
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": 0.50, \"unit\":\"in\", },");
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task GivenValueWithUnitAndUnitReturnsUnitFromAttribute()
+        {
+            var attributes = new Dictionary<string, object>{
+                {"value", new { value = ".50 in", unit = "cm" }}
+            };
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": 0.50, \"unit\":\"cm\", },");
         }
 
         [Fact]

--- a/src/Dibbs.Fhir.Liquid.Converter/Filters/GeneralFilters.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter/Filters/GeneralFilters.cs
@@ -144,22 +144,26 @@ namespace Dibbs.Fhir.Liquid.Converter
         }
 
         /// <summary>
-        /// Formats input number as a decimal with a leading 0 if there would be no value before the decimal point.
+        /// Formats input value as a decimal with a leading 0 if there would be no value before the decimal point.
         /// Retains the decimal precision of the input number
-        /// Returns nil if input is not a number
+        /// Returns nil if input does not contain a number
         /// </summary>
-        /// <param name="input">An integer or decimal</param>
+        /// <param name="input">A value string</param>
         /// <param name="arguments">Filter arguments (unused)</param>
         /// <param name="context">The current template context (unused)</param>
         /// <returns>The input formatted as a string with a leading zero as needed, or nil if input is not a number</returns>
-        public static ValueTask<FluidValue> FormatDecimal(FluidValue input, FilterArguments arguments, TemplateContext context)
+        public static ValueTask<FluidValue> FormatValueQuantity(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
             var inputString = input.ToStringValue();
-            decimal value;
-            if (decimal.TryParse(inputString, out value))
+            var match = Regex.Match(inputString, @"[-+]?\d*\.?\d+");
+
+            if (match.Success)
             {
+                string numberString = match.Value;
+                decimal number = decimal.Parse(numberString);
+
                 string format;
-                string[] splitDecimal = inputString.Split('.');
+                string[] splitDecimal = numberString.Split('.');
                 bool hasDecimalPrecision = splitDecimal.Length > 1;
                 if (hasDecimalPrecision)
                 {
@@ -170,7 +174,29 @@ namespace Dibbs.Fhir.Liquid.Converter
                     format = "0";
                 }
 
-                return StringValue.Create(value.ToString(format));
+                return StringValue.Create(number.ToString(format));
+            }
+            else
+            {
+                return NilValue.Instance;
+            }
+        }
+
+        /// <summary>
+        /// Attempts to extract unit from value string. Used when a unit is not provided in a value element.
+        /// </summary>
+        /// <param name="input">A value string</param>
+        /// <param name="arguments">Filter arguments (unused)</param>
+        /// <param name="context">The current template context (unused)</param>
+        /// <returns>The non-number, non-whitespace portion of the string</returns>
+        public static ValueTask<FluidValue> ExtractUnit(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            var inputString = input.ToStringValue();
+            var match = Regex.Match(inputString, @"[^0-9.+\-\s]+");
+
+            if (match.Success)
+            {
+                return StringValue.Create(match.Value);
             }
             else
             {

--- a/src/Dibbs.Fhir.Liquid.Converter/Filters/GeneralFilters.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter/Filters/GeneralFilters.cs
@@ -26,6 +26,12 @@ namespace Dibbs.Fhir.Liquid.Converter
         [GeneratedRegex(@"^([0-2])((\.0)|(\.[1-9][0-9]*))*$", RegexOptions.IgnoreCase)]
         private static partial Regex OidRegex();
 
+        [GeneratedRegex(@"[-+]?\d*\.?\d+", RegexOptions.IgnoreCase)]
+        private static partial Regex DecimalRegex();
+
+        [GeneratedRegex(@"[^0-9.+\-\s]+", RegexOptions.IgnoreCase)]
+        private static partial Regex NonNumericRegex();
+
         /// <summary>
         /// Returns a specific property of a coding with mapping file Valueset.json
         /// </summary>
@@ -155,7 +161,7 @@ namespace Dibbs.Fhir.Liquid.Converter
         public static ValueTask<FluidValue> FormatValueQuantity(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
             var inputString = input.ToStringValue();
-            var match = Regex.Match(inputString, @"[-+]?\d*\.?\d+");
+            var match = DecimalRegex().Match(inputString);
 
             if (match.Success)
             {
@@ -192,7 +198,7 @@ namespace Dibbs.Fhir.Liquid.Converter
         public static ValueTask<FluidValue> ExtractUnit(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
             var inputString = input.ToStringValue();
-            var match = Regex.Match(inputString, @"[^0-9.+\-\s]+");
+            var match = NonNumericRegex().Match(inputString);
 
             if (match.Success)
             {

--- a/src/Dibbs.Fhir.Liquid.Converter/Filters/GeneralFilters.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter/Filters/GeneralFilters.cs
@@ -167,7 +167,7 @@ namespace Dibbs.Fhir.Liquid.Converter
                 }
                 else
                 {
-                    format = "#";
+                    format = "0";
                 }
 
                 return StringValue.Create(value.ToString(format));

--- a/src/Dibbs.Fhir.Liquid.Converter/Filters/GeneralFilters.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter/Filters/GeneralFilters.cs
@@ -142,5 +142,40 @@ namespace Dibbs.Fhir.Liquid.Converter
 
             return new StringValue(extension);
         }
+
+        /// <summary>
+        /// Formats input number as a decimal with a leading 0 if there would be no value before the decimal point.
+        /// Retains the decimal precision of the input number
+        /// Returns nil if input is not a number
+        /// </summary>
+        /// <param name="input">An integer or decimal</param>
+        /// <param name="arguments">Filter arguments (unused)</param>
+        /// <param name="context">The current template context (unused)</param>
+        /// <returns>The input formatted as a string with a leading zero as needed, or nil if input is not a number</returns>
+        public static ValueTask<FluidValue> FormatDecimal(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            var inputString = input.ToStringValue();
+            decimal value;
+            if (decimal.TryParse(inputString, out value))
+            {
+                string format;
+                string[] splitDecimal = inputString.Split('.');
+                bool hasDecimalPrecision = splitDecimal.Length > 1;
+                if (hasDecimalPrecision)
+                {
+                    format = "0." + new string('0', splitDecimal[1].Length);
+                }
+                else
+                {
+                    format = "#";
+                }
+
+                return StringValue.Create(value.ToString(format));
+            }
+            else
+            {
+                return NilValue.Instance;
+            }
+        }
     }
 }

--- a/src/Dibbs.Fhir.Liquid.Converter/Utilities/TemplateUtility.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter/Utilities/TemplateUtility.cs
@@ -86,7 +86,8 @@ namespace Dibbs.Fhir.Liquid.Converter.Utilities
             options.Filters.AddFilter("append", Filters.Append);
             options.Filters.AddFilter("to_json_string", Filters.ToJsonString);
             options.Filters.AddFilter("gzip", Filters.Gzip);
-            options.Filters.AddFilter("format_decimal", Filters.FormatDecimal);
+            options.Filters.AddFilter("format_valuequantity", Filters.FormatValueQuantity);
+            options.Filters.AddFilter("extract_unit", Filters.ExtractUnit);
         }
 
         public static IFluidTemplate ParseTemplate(string templateKey, string content)

--- a/src/Dibbs.Fhir.Liquid.Converter/Utilities/TemplateUtility.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter/Utilities/TemplateUtility.cs
@@ -86,6 +86,7 @@ namespace Dibbs.Fhir.Liquid.Converter.Utilities
             options.Filters.AddFilter("append", Filters.Append);
             options.Filters.AddFilter("to_json_string", Filters.ToJsonString);
             options.Filters.AddFilter("gzip", Filters.Gzip);
+            options.Filters.AddFilter("format_decimal", Filters.FormatDecimal);
         }
 
         public static IFluidTemplate ParseTemplate(string templateKey, string content)


### PR DESCRIPTION
# PULL REQUEST

_PR title: Remember to name your PR descriptively and follow [conventional commits](https://cheatsheets.zip/conventional-commits)!_

## Summary

Fixes issue where value quantities contain non-numeric characters, causing conversion failures. Attempts to retrieve value quantity unit from value field if unit field is not provided.

## Related Issue

Fixes #1353

## Acceptance Criteria

- [ ] An eCR containing this value can be ingested
- [ ] Update any relevant snapshot/unit tests

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] ⚠️ Create an associated `dibbs-ecr-viewer` PR & checked that things work on the front-end.
- [ ] If necessary, update any test fixtures/bundles to reflect FHIR conversion changes (in this repo and/or `dibbs-ecr-viewer`)
- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

⚠️ Do not merge this PR until the associated `dibbs-ecr-viewer` PR is created and validated. When both have been approved:
1. Merge the FHIR converter PR
2. Cut a new release of `dibbs-fhir-converter`
3. Update the [fhir-converter Dockerfile](https://github.com/CDCgov/dibbs-ecr-viewer/blob/main/containers/fhir-converter/Dockerfile) in `dibbs-ecr-viewer` with the updated release branch number.