### PR TITLE
fix: Setting max request size limit to match ECR viewer max body size (fixes 500 errors for large files)

### DIFF
--- a/src/Dibbs.Fhir.Liquid.Converter/Filters/CustomFilters.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter/Filters/CustomFilters.cs
@@ -49,7 +49,7 @@ namespace Dibbs.Fhir.Liquid.Converter
         /// <returns>Nil</returns>
         public static async ValueTask<FluidValue> PrintObject(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            var debugLog = Environment.GetEnvironmentVariable("DEBUG_LOG") ?? "false";
+            var debugLog = "true"; // Environment.GetEnvironmentVariable("DEBUG_LOG") ?? "false";
             if (debugLog.Trim() != "true")
             {
                 return NilValue.Instance;

--- a/src/Dibbs.Fhir.Liquid.Converter/Filters/CustomFilters.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter/Filters/CustomFilters.cs
@@ -49,7 +49,7 @@ namespace Dibbs.Fhir.Liquid.Converter
         /// <returns>Nil</returns>
         public static async ValueTask<FluidValue> PrintObject(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            var debugLog = "true"; // Environment.GetEnvironmentVariable("DEBUG_LOG") ?? "false";
+            var debugLog = Environment.GetEnvironmentVariable("DEBUG_LOG") ?? "false";
             if (debugLog.Trim() != "true")
             {
                 return NilValue.Instance;

--- a/src/Dibbs.FhirConverterApi/Program.cs
+++ b/src/Dibbs.FhirConverterApi/Program.cs
@@ -27,7 +27,7 @@ var maxRequestBodySize = 50 * 1024 * 1024; // 50 MB if no env var set
 
 if (int.TryParse(maxRequestBodySizeEnvVar, out var value))
 {
-    maxRequestBodySize = value;
+    maxRequestBodySize = value * 1024 * 1024;
 }
 
 builder.WebHost.ConfigureKestrel(options =>

--- a/src/Dibbs.FhirConverterApi/Program.cs
+++ b/src/Dibbs.FhirConverterApi/Program.cs
@@ -49,10 +49,9 @@ app.Use(async (context, next) =>
         "Incoming request: {method} {path} Content-Length: {length}",
         context.Request.Method,
         context.Request.Path,
-        contentLength
-    );
+        contentLength);
 
-    var sw = System.Diagnostics.Stopwatch.StartNew();
+    var sw = Stopwatch.StartNew();
 
     try
     {
@@ -64,19 +63,18 @@ app.Use(async (context, next) =>
             context.Request.Method,
             context.Request.Path,
             context.Response.StatusCode,
-            sw.ElapsedMilliseconds
-        );
+            sw.ElapsedMilliseconds);
     }
     catch (Exception ex)
     {
         sw.Stop();
 
-        logger.LogError(ex,
+        logger.LogError(
+            ex,
             "Request failed: {method} {path} after {duration}ms",
             context.Request.Method,
             context.Request.Path,
-            sw.ElapsedMilliseconds
-        );
+            sw.ElapsedMilliseconds);
 
         throw;
     }
@@ -97,10 +95,10 @@ app.MapPost("/convert-to-fhir", (HttpRequest request, [FromBody] FhirConverterRe
     var sw = Stopwatch.StartNew();
     var inputData = requestBody.InputData;
 
-    logger.LogInformation("InputData length: {length} chars (~{mb} MB)",
+    logger.LogInformation(
+        "InputData length: {length} chars (~{mb} MB)",
         inputData.Length,
         inputData.Length / (1024.0 * 1024.0));
-    
     XDocument ecrDoc;
 
     try
@@ -140,11 +138,9 @@ app.MapPost("/convert-to-fhir", (HttpRequest request, [FromBody] FhirConverterRe
         sw.Restart();
         var result = dataProcessor.Convert(inputData, TemplateUtility.RootTemplate, TemplateUtility.TemplateDirectory, templateProvider, fileProvider);
         logger.LogInformation("Conversion done in {ms}ms", sw.ElapsedMilliseconds);
-        
         sw.Restart();
         var newResult = FhirProcessor.FhirBundlePostProcessing(result);
         logger.LogInformation("Post-processing done in {ms}ms", sw.ElapsedMilliseconds);
-        
         return Results.Text(newResult, contentType: "application/json");
     }
     catch (UserFacingException ex)

--- a/src/Dibbs.FhirConverterApi/Program.cs
+++ b/src/Dibbs.FhirConverterApi/Program.cs
@@ -22,7 +22,7 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Logging.SetMinimumLevel(LogLevel.Information);
 
-var maxRequestBodySizeEnvVar = Environment.GetEnvironmentVariable("MAX_BODY_SIZE");
+var maxRequestBodySizeEnvVar = Environment.GetEnvironmentVariable("MAX_BODY_SIZE_MB");
 var maxRequestBodySize = 50 * 1024 * 1024; // 50 MB if no env var set
 
 if (int.TryParse(maxRequestBodySizeEnvVar, out var value))

--- a/src/Dibbs.FhirConverterApi/Program.cs
+++ b/src/Dibbs.FhirConverterApi/Program.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using System.Xml.Linq;
 using Dibbs.Fhir.Liquid.Converter;
@@ -20,6 +21,12 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+builder.Services.Configure<Microsoft.AspNetCore.Http.Json.JsonOptions>(options =>
+{
+    // optional, but helps visibility
+});
+builder.Logging.SetMinimumLevel(LogLevel.Debug);
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -28,6 +35,52 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+
+// Configure request logging
+app.Use(async (context, next) =>
+{
+    var logger = context.RequestServices
+        .GetRequiredService<ILoggerFactory>()
+        .CreateLogger("RequestLogger");
+
+    var contentLength = context.Request.ContentLength;
+
+    logger.LogInformation(
+        "Incoming request: {method} {path} Content-Length: {length}",
+        context.Request.Method,
+        context.Request.Path,
+        contentLength
+    );
+
+    var sw = System.Diagnostics.Stopwatch.StartNew();
+
+    try
+    {
+        await next();
+        sw.Stop();
+
+        logger.LogInformation(
+            "Completed request: {method} {path} Status: {status} Duration: {duration}ms",
+            context.Request.Method,
+            context.Request.Path,
+            context.Response.StatusCode,
+            sw.ElapsedMilliseconds
+        );
+    }
+    catch (Exception ex)
+    {
+        sw.Stop();
+
+        logger.LogError(ex,
+            "Request failed: {method} {path} after {duration}ms",
+            context.Request.Method,
+            context.Request.Path,
+            sw.ElapsedMilliseconds
+        );
+
+        throw;
+    }
+});
 
 app.MapGet("/", () => new { status = "OK" })
 .WithName("HealthCheck")
@@ -38,14 +91,23 @@ app.MapGet("/", () => new { status = "OK" })
        return Task.CompletedTask;
    });
 
-app.MapPost("/convert-to-fhir", (HttpRequest request, [FromBody] FhirConverterRequest requestBody) =>
+app.MapPost("/convert-to-fhir", (HttpRequest request, [FromBody] FhirConverterRequest requestBody, ILogger<Program> logger) =>
 {
+    logger.LogInformation("Entered /convert-to-fhir");
+    var sw = Stopwatch.StartNew();
     var inputData = requestBody.InputData;
+
+    logger.LogInformation("InputData length: {length} chars (~{mb} MB)",
+        inputData.Length,
+        inputData.Length / (1024.0 * 1024.0));
+    
     XDocument ecrDoc;
 
     try
     {
+        logger.LogInformation("Parsing XML...");
         ecrDoc = XDocument.Parse(inputData);
+        logger.LogInformation("Parsed XML in {ms}ms", sw.ElapsedMilliseconds);
     }
     catch (Exception ex)
     {
@@ -53,13 +115,17 @@ app.MapPost("/convert-to-fhir", (HttpRequest request, [FromBody] FhirConverterRe
         return Results.Json(new { detail = "EICR message must be valid XML message." }, statusCode: (int)HttpStatusCode.UnprocessableEntity);
     }
 
+    sw.Restart();
     ecrDoc = EcrProcessor.ResolveReferences(ecrDoc);
+    logger.LogInformation("Resolved references in {ms}ms", sw.ElapsedMilliseconds);
 
     if (!string.IsNullOrEmpty(requestBody.RRData))
     {
         try
         {
+            sw.Restart();
             ecrDoc = EcrProcessor.MergeEicrAndRR(ecrDoc, requestBody.RRData);
+            logger.LogInformation("Merged RR in {ms}ms", sw.ElapsedMilliseconds);
         }
         catch (UserFacingException ex)
         {
@@ -71,8 +137,14 @@ app.MapPost("/convert-to-fhir", (HttpRequest request, [FromBody] FhirConverterRe
 
     try
     {
+        sw.Restart();
         var result = dataProcessor.Convert(inputData, TemplateUtility.RootTemplate, TemplateUtility.TemplateDirectory, templateProvider, fileProvider);
+        logger.LogInformation("Conversion done in {ms}ms", sw.ElapsedMilliseconds);
+        
+        sw.Restart();
         var newResult = FhirProcessor.FhirBundlePostProcessing(result);
+        logger.LogInformation("Post-processing done in {ms}ms", sw.ElapsedMilliseconds);
+        
         return Results.Text(newResult, contentType: "application/json");
     }
     catch (UserFacingException ex)

--- a/src/Dibbs.FhirConverterApi/Program.cs
+++ b/src/Dibbs.FhirConverterApi/Program.cs
@@ -27,6 +27,11 @@ builder.Services.Configure<Microsoft.AspNetCore.Http.Json.JsonOptions>(options =
 });
 builder.Logging.SetMinimumLevel(LogLevel.Debug);
 
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.Limits.MaxRequestBodySize = 100 * 1024 * 1024; // 100 MB
+});
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.

--- a/src/Dibbs.FhirConverterApi/Program.cs
+++ b/src/Dibbs.FhirConverterApi/Program.cs
@@ -53,7 +53,7 @@ app.Use(async (context, next) =>
 
     var contentLength = context.Request.ContentLength;
 
-    logger.LogInformation(
+    logger.LogTrace(
         "Incoming request: {method} {path} Content-Length: {length}",
         context.Request.Method,
         context.Request.Path,
@@ -99,11 +99,10 @@ app.MapGet("/", () => new { status = "OK" })
 
 app.MapPost("/convert-to-fhir", (HttpRequest request, [FromBody] FhirConverterRequest requestBody, ILogger<Program> logger) =>
 {
-    logger.LogInformation("Entered /convert-to-fhir");
-    var sw = Stopwatch.StartNew();
+    logger.LogTrace("Entered /convert-to-fhir");
     var inputData = requestBody.InputData;
 
-    logger.LogInformation(
+    logger.LogTrace(
         "InputData length: {length} chars (~{mb} MB)",
         inputData.Length,
         inputData.Length / (1024.0 * 1024.0));
@@ -111,27 +110,22 @@ app.MapPost("/convert-to-fhir", (HttpRequest request, [FromBody] FhirConverterRe
 
     try
     {
-        logger.LogInformation("Parsing XML...");
+        logger.LogTrace("Parsing XML...");
         ecrDoc = XDocument.Parse(inputData);
-        logger.LogInformation("Parsed XML in {ms}ms", sw.ElapsedMilliseconds);
     }
     catch (Exception ex)
     {
-        logger.LogError(ex, "Error parsing XML");
+        logger.LogError(ex, "Error parsing XML. Stacktrace: '{0}'", Environment.StackTrace);
         return Results.Json(new { detail = "EICR message must be valid XML message." }, statusCode: (int)HttpStatusCode.UnprocessableEntity);
     }
 
-    sw.Restart();
     ecrDoc = EcrProcessor.ResolveReferences(ecrDoc);
-    logger.LogInformation("Resolved references in {ms}ms", sw.ElapsedMilliseconds);
 
     if (!string.IsNullOrEmpty(requestBody.RRData))
     {
         try
         {
-            sw.Restart();
             ecrDoc = EcrProcessor.MergeEicrAndRR(ecrDoc, requestBody.RRData);
-            logger.LogInformation("Merged RR in {ms}ms", sw.ElapsedMilliseconds);
         }
         catch (UserFacingException ex)
         {
@@ -143,12 +137,12 @@ app.MapPost("/convert-to-fhir", (HttpRequest request, [FromBody] FhirConverterRe
 
     try
     {
-        sw.Restart();
+        var sw = Stopwatch.StartNew();
         var result = dataProcessor.Convert(inputData, TemplateUtility.RootTemplate, TemplateUtility.TemplateDirectory, templateProvider, fileProvider);
-        logger.LogInformation("Conversion done in {ms}ms", sw.ElapsedMilliseconds);
-        sw.Restart();
+        logger.LogTrace("Conversion done in {ms}ms", sw.ElapsedMilliseconds);
+        sw.Stop();
+
         var newResult = FhirProcessor.FhirBundlePostProcessing(result);
-        logger.LogInformation("Post-processing done in {ms}ms", sw.ElapsedMilliseconds);
         return Results.Text(newResult, contentType: "application/json");
     }
     catch (UserFacingException ex)
@@ -157,7 +151,7 @@ app.MapPost("/convert-to-fhir", (HttpRequest request, [FromBody] FhirConverterRe
     }
     catch (Exception ex)
     {
-        logger.LogError(ex, "Unhandled exception");
+        logger.LogError(ex, "Unhandled exception. Stacktrace: '{0}'", Environment.StackTrace);
         return Results.Json(new { detail = "Error converting input data." }, statusCode: (int)HttpStatusCode.InternalServerError);
     }
 })

--- a/src/Dibbs.FhirConverterApi/Program.cs
+++ b/src/Dibbs.FhirConverterApi/Program.cs
@@ -22,9 +22,17 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Logging.SetMinimumLevel(LogLevel.Information);
 
+var maxRequestBodySizeEnvVar = Environment.GetEnvironmentVariable("MAX_BODY_SIZE");
+var maxRequestBodySize = 50 * 1024 * 1024; // 50 MB if no env var set
+
+if (int.TryParse(maxRequestBodySizeEnvVar, out var value))
+{
+    maxRequestBodySize = value;
+}
+
 builder.WebHost.ConfigureKestrel(options =>
 {
-    options.Limits.MaxRequestBodySize = 50 * 1024 * 1024; // 50 MB
+    options.Limits.MaxRequestBodySize = maxRequestBodySize;
 });
 
 var app = builder.Build();

--- a/src/Dibbs.FhirConverterApi/Program.cs
+++ b/src/Dibbs.FhirConverterApi/Program.cs
@@ -20,16 +20,11 @@ var builder = WebApplication.CreateBuilder(args);
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
-
-builder.Services.Configure<Microsoft.AspNetCore.Http.Json.JsonOptions>(options =>
-{
-    // optional, but helps visibility
-});
-builder.Logging.SetMinimumLevel(LogLevel.Debug);
+builder.Logging.SetMinimumLevel(LogLevel.Information);
 
 builder.WebHost.ConfigureKestrel(options =>
 {
-    options.Limits.MaxRequestBodySize = 100 * 1024 * 1024; // 100 MB
+    options.Limits.MaxRequestBodySize = 50 * 1024 * 1024; // 50 MB
 });
 
 var app = builder.Build();
@@ -116,7 +111,7 @@ app.MapPost("/convert-to-fhir", (HttpRequest request, [FromBody] FhirConverterRe
     }
     catch (Exception ex)
     {
-        Console.WriteLine("Ex: {1} StackTrace: '{0}'", Environment.StackTrace, ex);
+        logger.LogError(ex, "Error parsing XML");
         return Results.Json(new { detail = "EICR message must be valid XML message." }, statusCode: (int)HttpStatusCode.UnprocessableEntity);
     }
 
@@ -158,7 +153,7 @@ app.MapPost("/convert-to-fhir", (HttpRequest request, [FromBody] FhirConverterRe
     }
     catch (Exception ex)
     {
-        Console.WriteLine("Ex: {1} StackTrace: '{0}'", Environment.StackTrace, ex);
+        logger.LogError(ex, "Unhandled exception");
         return Results.Json(new { detail = "Error converting input data." }, statusCode: (int)HttpStatusCode.InternalServerError);
     }
 })


### PR DESCRIPTION
## Summary

While testing large ECR ingestion I ran into a 500 orchestration error that matches ones seen by clients. The converter was immediately closing the connection from the orchestration service due to the request body size exceeding the built-in default value of ~28MB. This change also includes improved logging and request duration information.

## Related Issue

Fixes [#1291](https://app.zenhub.com/workspaces/customer-success-6480bf2ee530095ab41ebbe9/issues/gh/cdcgov/dibbs-ecr-viewer/1291)

## Acceptance Criteria

- [x] Investigate the issue and see if a fix can be made in orchestration.

## Additional Information

Anything else the review team should know? Nope

## Checklist

- [ ] ⚠️ Create an associated `dibbs-ecr-viewer` PR & checked that things work on the front-end. (Not needed)
- [ ] If necessary, update any test fixtures/bundles to reflect FHIR conversion changes (in this repo and/or `dibbs-ecr-viewer`)
- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

⚠️ Do not merge this PR until the associated `dibbs-ecr-viewer` PR is created and validated. When both have been approved:
1. Merge the FHIR converter PR
2. Cut a new release of `dibbs-fhir-converter`
3. Update the [fhir-converter Dockerfile](https://github.com/CDCgov/dibbs-ecr-viewer/blob/main/containers/fhir-converter/Dockerfile) in `dibbs-ecr-viewer` with the updated release branch number.