### PR TITLE
fix: Using document id for uuid generator to reduce memory footprint.

### DIFF
--- a/data/Templates/eCR/EICR.liquid
+++ b/data/Templates/eCR/EICR.liquid
@@ -1,12 +1,9 @@
-{% assign eicrDocumentId = msg._originalData | generate_uuid -%}
-{% if msg.ClinicalDocument.id -%}
-  {% if msg.ClinicalDocument.id.extension -%}
-    {% comment %} If extension exists, use that {% endcomment %}
-    {% assign eicrDocumentId = msg.ClinicalDocument.id.extension -%}
-  {% elsif msg.ClinicalDocument.id.root -%}
-    {% comment %} If extension does not exist and root does, use that {% endcomment %}
-    {% assign eicrDocumentId = msg.ClinicalDocument.id.root -%}
-  {% endif -%}
+{% if msg.ClinicalDocument.id and msg.ClinicalDocument.id.extension -%}
+  {% comment %} If extension exists, use that {% endcomment %}
+  {% assign eicrDocumentId = msg.ClinicalDocument.id.extension -%}
+{% elsif msg.ClinicalDocument.id and msg.ClinicalDocument.id.root -%}
+  {% comment %} If extension does not exist and root does, use that {% endcomment %}
+  {% assign eicrDocumentId = msg.ClinicalDocument.id.root -%}
 {% else -%}
   {% assign eicrDocumentId = msg._originalData | generate_uuid -%}
 {% endif -%}

--- a/data/Templates/eCR/Header.liquid
+++ b/data/Templates/eCR/Header.liquid
@@ -1,4 +1,4 @@
-{% assign compositionId = msg.ClinicalDocument | to_json_string | generate_uuid -%}
+{% assign compositionId = msg.ClinicalDocument.id | to_json_string | generate_uuid -%}
 {% evaluate practitionerId using 'Utils/GenerateId' obj: msg.ClinicalDocument.componentOf.encompassingEncounter.responsibleParty.assignedEntity -%}
 {% include 'Resource/Composition', composition: msg.ClinicalDocument, practitionerId: practitionerId, ID: compositionId -%}
 {% include 'Reference/Composition/Subject', ID: compositionId, REF: fullPatientId -%}

--- a/data/Templates/eCR/Header.liquid
+++ b/data/Templates/eCR/Header.liquid
@@ -1,4 +1,8 @@
-{% assign compositionId = msg.ClinicalDocument.id | to_json_string | generate_uuid -%}
+{% if msg.ClinicalDocument.id %}
+  {% assign compositionId = msg.ClinicalDocument.id | to_json_string | generate_uuid -%}
+{% else %}
+  {% assign compositionId = msg.ClinicalDocument | to_json_string | generate_uuid -%}
+{% endif %}
 {% evaluate practitionerId using 'Utils/GenerateId' obj: msg.ClinicalDocument.componentOf.encompassingEncounter.responsibleParty.assignedEntity -%}
 {% include 'Resource/Composition', composition: msg.ClinicalDocument, practitionerId: practitionerId, ID: compositionId -%}
 {% include 'Reference/Composition/Subject', ID: compositionId, REF: fullPatientId -%}

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/CDAR2_IG_PHCASERPT_R2_D2_SAMPLE-expected.json
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/CDAR2_IG_PHCASERPT_R2_D2_SAMPLE-expected.json
@@ -14,10 +14,10 @@
   "timestamp": "2018-11-07T09:44:21-05:00",
   "entry": [
     {
-      "fullUrl": "urn:uuid:23d5cd25-76ef-70f0-964c-521a1131ddf3",
+      "fullUrl": "urn:uuid:7a5c1d80-fd56-3bc1-f3b8-8d282302727b",
       "resource": {
         "resourceType": "Composition",
-        "id": "23d5cd25-76ef-70f0-964c-521a1131ddf3",
+        "id": "7a5c1d80-fd56-3bc1-f3b8-8d282302727b",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/ecr/StructureDefinition/eicr-composition"

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/CDAR2_IG_PHCASERPT_R2_D2_SAMPLE-expected.json
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/CDAR2_IG_PHCASERPT_R2_D2_SAMPLE-expected.json
@@ -473,7 +473,9 @@
         ],
         "name": "Good Health Hospital",
         "address": {
-          "line": ["1000 Hospital Lane"],
+          "line": [
+            "1000 Hospital Lane"
+          ],
           "city": "Ann Arbor",
           "state": "MI",
           "country": "US",
@@ -512,7 +514,9 @@
         "name": "Good Health Hospital",
         "address": [
           {
-            "line": ["1000 Hospital Lane"],
+            "line": [
+              "1000 Hospital Lane"
+            ],
             "city": "Ann Arbor",
             "state": "MI",
             "country": "US",
@@ -558,13 +562,19 @@
         "name": [
           {
             "family": "Seven",
-            "given": ["Henry"],
-            "suffix": ["M.D."]
+            "given": [
+              "Henry"
+            ],
+            "suffix": [
+              "M.D."
+            ]
           }
         ],
         "address": [
           {
-            "line": ["1002 Healthcare Drive"],
+            "line": [
+              "1002 Healthcare Drive"
+            ],
             "city": "Ann Arbor",
             "state": "MI",
             "country": "US",
@@ -610,7 +620,9 @@
         "name": "Community Health and Hospitals",
         "address": [
           {
-            "line": ["1002 Healthcare Drive"],
+            "line": [
+              "1002 Healthcare Drive"
+            ],
             "city": "Ann Arbor",
             "state": "MI",
             "country": "US",
@@ -633,7 +645,9 @@
         "name": "Good Health Hospital",
         "address": [
           {
-            "line": ["1000 Hospital Lane"],
+            "line": [
+              "1000 Hospital Lane"
+            ],
             "city": "Ann Arbor",
             "state": "MI",
             "country": "US",
@@ -699,12 +713,18 @@
           {
             "use": "official",
             "family": "Everywoman",
-            "given": ["Eve", "H"]
+            "given": [
+              "Eve",
+              "H"
+            ]
           },
           {
             "use": "usual",
             "family": "Everywoman",
-            "given": ["Ruth", "L"]
+            "given": [
+              "Ruth",
+              "L"
+            ]
           }
         ],
         "birthDate": "1974-11-24",
@@ -770,7 +790,9 @@
         "address": [
           {
             "use": "home",
-            "line": ["2222 Home Street"],
+            "line": [
+              "2222 Home Street"
+            ],
             "city": "Ann Arbor",
             "state": "MI",
             "country": "US",
@@ -911,7 +933,10 @@
           {
             "use": "official",
             "family": "Mum",
-            "given": ["Martha", "L"]
+            "given": [
+              "Martha",
+              "L"
+            ]
           }
         ],
         "telecom": [
@@ -928,7 +953,9 @@
         "address": [
           {
             "use": "home",
-            "line": ["4444 Home Street"],
+            "line": [
+              "4444 Home Street"
+            ],
             "city": "Ann Arbor",
             "state": "MI",
             "country": "US",
@@ -2056,7 +2083,9 @@
               {
                 "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-address-extension",
                 "valueAddress": {
-                  "line": ["1170 N Rancho Robles Rd"],
+                  "line": [
+                    "1170 N Rancho Robles Rd"
+                  ],
                   "city": "Oracle",
                   "state": "AZ",
                   "country": "US",
@@ -2160,7 +2189,9 @@
         "name": "CDC",
         "address": [
           {
-            "line": ["Peachtree St"],
+            "line": [
+              "Peachtree St"
+            ],
             "city": "Ann Arbor",
             "state": "Georgia"
           }
@@ -2274,7 +2305,9 @@
         "resourceType": "Observation",
         "id": "da69efeb-b20d-b7b6-dc3a-67c48327ad3b",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2318,7 +2351,9 @@
         "resourceType": "Observation",
         "id": "5bc4d32a-aa57-1d96-5ea6-87d48bcd7516",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2362,7 +2397,9 @@
         "resourceType": "Observation",
         "id": "ca049d29-37b4-4b96-6940-f506b60966cf",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2406,7 +2443,9 @@
         "resourceType": "Observation",
         "id": "a0453f8b-628e-e30c-7900-06229f409f77",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2450,7 +2489,9 @@
         "resourceType": "Observation",
         "id": "bdfc681c-3255-664f-ee64-01672d1785de",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2494,7 +2535,9 @@
         "resourceType": "Observation",
         "id": "26c60c1c-e7c4-faf2-c3db-6b2eaa81d96b",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2538,7 +2581,9 @@
         "resourceType": "Observation",
         "id": "eb7cc925-1f69-4738-d033-24c41dfdb02e",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2582,7 +2627,9 @@
         "resourceType": "Observation",
         "id": "e885f483-ce24-e078-5b21-ccc7c5031e48",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2626,7 +2673,9 @@
         "resourceType": "Observation",
         "id": "9f81a6a6-5e42-8107-7464-31ed8eea4d78",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_EveEverywoman-expected.json
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_EveEverywoman-expected.json
@@ -14,10 +14,10 @@
   "timestamp": "2020-11-07T09:44:21-05:00",
   "entry": [
     {
-      "fullUrl": "urn:uuid:0ecd1946-2f5a-6691-ba82-e3fd6e30e8dc",
+      "fullUrl": "urn:uuid:7a5c1d80-fd56-3bc1-f3b8-8d282302727b",
       "resource": {
         "resourceType": "Composition",
-        "id": "0ecd1946-2f5a-6691-ba82-e3fd6e30e8dc",
+        "id": "7a5c1d80-fd56-3bc1-f3b8-8d282302727b",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/ecr/StructureDefinition/eicr-composition"
@@ -1488,7 +1488,7 @@
           "reference": "Patient/f238f1ae-2f55-cd21-5c90-5e68a10af8ce"
         },
         "period": {
-          "start": "201810081426-0500"
+          "start": "2018-10-08T14:26:00-05:00"
         },
         "participant": [
           {
@@ -1507,7 +1507,7 @@
               "reference": "Practitioner/332b44ba-27b8-6426-b122-df06a0d9730f"
             },
             "period": {
-              "start": "201810081426-0500"
+              "start": "2018-10-08T14:26:00-05:00"
             },
             "modifierExtension": [
               {

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_EveEverywoman-expected.json
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_EveEverywoman-expected.json
@@ -636,7 +636,9 @@
         ],
         "name": "Good Health Hospital",
         "address": {
-          "line": ["1000 Hospital Lane"],
+          "line": [
+            "1000 Hospital Lane"
+          ],
           "city": "Ann Arbor",
           "state": "MI",
           "country": "US",
@@ -675,7 +677,9 @@
         "name": "Good Health Hospital",
         "address": [
           {
-            "line": ["1000 Hospital Lane"],
+            "line": [
+              "1000 Hospital Lane"
+            ],
             "city": "Ann Arbor",
             "state": "MI",
             "country": "US",
@@ -721,13 +725,19 @@
         "name": [
           {
             "family": "Seven",
-            "given": ["Henry"],
-            "suffix": ["M.D."]
+            "given": [
+              "Henry"
+            ],
+            "suffix": [
+              "M.D."
+            ]
           }
         ],
         "address": [
           {
-            "line": ["1002 Healthcare Drive"],
+            "line": [
+              "1002 Healthcare Drive"
+            ],
             "city": "Ann Arbor",
             "state": "MI",
             "country": "US",
@@ -773,7 +783,9 @@
         "name": "Community Health and Hospitals",
         "address": [
           {
-            "line": ["1002 Healthcare Drive"],
+            "line": [
+              "1002 Healthcare Drive"
+            ],
             "city": "Ann Arbor",
             "state": "MI",
             "country": "US",
@@ -1234,7 +1246,9 @@
         "name": "Good Health Hospital",
         "address": [
           {
-            "line": ["1000 Hospital Lane"],
+            "line": [
+              "1000 Hospital Lane"
+            ],
             "city": "Ann Arbor",
             "state": "MI",
             "country": "US",
@@ -1300,12 +1314,18 @@
           {
             "use": "official",
             "family": "Everywoman",
-            "given": ["Eve", "H"]
+            "given": [
+              "Eve",
+              "H"
+            ]
           },
           {
             "use": "usual",
             "family": "Everywoman",
-            "given": ["Ruth", "L"]
+            "given": [
+              "Ruth",
+              "L"
+            ]
           }
         ],
         "birthDate": "1974-11-24",
@@ -1388,7 +1408,9 @@
         "address": [
           {
             "use": "home",
-            "line": ["2222 Home Street"],
+            "line": [
+              "2222 Home Street"
+            ],
             "city": "Ann Arbor",
             "state": "MI",
             "country": "US",
@@ -1525,13 +1547,20 @@
         "name": [
           {
             "family": "Smith",
-            "given": ["John", "D"],
-            "suffix": ["MD"]
+            "given": [
+              "John",
+              "D"
+            ],
+            "suffix": [
+              "MD"
+            ]
           }
         ],
         "address": [
           {
-            "line": ["100 Main St. Suite 100"],
+            "line": [
+              "100 Main St. Suite 100"
+            ],
             "city": "Hope Valley",
             "state": "RI",
             "country": "US",
@@ -1641,7 +1670,10 @@
           {
             "use": "official",
             "family": "Mum",
-            "given": ["Martha", "L"]
+            "given": [
+              "Martha",
+              "L"
+            ]
           }
         ],
         "telecom": [
@@ -1658,7 +1690,9 @@
         "address": [
           {
             "use": "home",
-            "line": ["4444 Home Street"],
+            "line": [
+              "4444 Home Street"
+            ],
             "city": "Ann Arbor",
             "state": "MI",
             "country": "US",
@@ -2545,7 +2579,9 @@
           {
             "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-address-extension",
             "valueAddress": {
-              "line": ["99 Football Stadium Road"],
+              "line": [
+                "99 Football Stadium Road"
+              ],
               "city": "My City",
               "state": "AZ",
               "country": "US",
@@ -2724,7 +2760,9 @@
           {
             "use": "official",
             "family": "Everyman",
-            "given": ["Adam"]
+            "given": [
+              "Adam"
+            ]
           }
         ],
         "patient": {
@@ -3162,7 +3200,9 @@
               {
                 "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-address-extension",
                 "valueAddress": {
-                  "line": ["1170 N Rancho Robles Rd"],
+                  "line": [
+                    "1170 N Rancho Robles Rd"
+                  ],
                   "city": "Oracle",
                   "state": "AZ",
                   "country": "US",
@@ -3183,7 +3223,9 @@
         "resourceType": "Observation",
         "id": "c241ed7b-dc3d-7055-5d3e-a307f8494b07",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -3230,7 +3272,9 @@
         "resourceType": "Observation",
         "id": "962570d9-01a7-db34-f8c9-57168e44510d",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -3414,7 +3458,9 @@
         "name": "University Hospital",
         "address": [
           {
-            "line": ["Peachtree St"],
+            "line": [
+              "Peachtree St"
+            ],
             "city": "Atlanta",
             "state": "Georgia"
           }
@@ -3538,7 +3584,9 @@
         "resourceType": "Observation",
         "id": "aa4503c3-c475-e3dd-96fa-814291526157",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -3589,7 +3637,9 @@
         "resourceType": "Observation",
         "id": "40db397d-91fe-7c16-2b20-b9d1b46f6140",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -3633,7 +3683,9 @@
         "resourceType": "Observation",
         "id": "5bc4d32a-aa57-1d96-5ea6-87d48bcd7516",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -3677,7 +3729,9 @@
         "resourceType": "Observation",
         "id": "ca049d29-37b4-4b96-6940-f506b60966cf",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -3721,7 +3775,9 @@
         "resourceType": "Observation",
         "id": "a0453f8b-628e-e30c-7900-06229f409f77",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -3765,7 +3821,9 @@
         "resourceType": "Observation",
         "id": "bdfc681c-3255-664f-ee64-01672d1785de",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -3809,7 +3867,9 @@
         "resourceType": "Observation",
         "id": "26c60c1c-e7c4-faf2-c3db-6b2eaa81d96b",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -3853,7 +3913,9 @@
         "resourceType": "Observation",
         "id": "eb7cc925-1f69-4738-d033-24c41dfdb02e",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -3897,7 +3959,9 @@
         "resourceType": "Observation",
         "id": "e885f483-ce24-e078-5b21-ccc7c5031e48",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -3941,7 +4005,9 @@
         "resourceType": "Observation",
         "id": "9f81a6a6-5e42-8107-7464-31ed8eea4d78",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -4337,7 +4403,9 @@
         ],
         "name": "Community Health and Hospitals",
         "address": {
-          "line": ["1002 Healthcare Drive"],
+          "line": [
+            "1002 Healthcare Drive"
+          ],
           "city": "Ann Arbor",
           "state": "MI",
           "country": "US",
@@ -4426,7 +4494,9 @@
         "resourceType": "Observation",
         "id": "44e6df0f-4e41-63ee-2bda-625369930b7c",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -4539,7 +4609,9 @@
         "resourceType": "Observation",
         "id": "ecf330de-e85f-0b34-5fdd-6dccdae41d6d",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
@@ -17,10 +17,10 @@
   "timestamp": "1985-07-28T23:28:26-06:00",
   "entry": [
     {
-      "fullUrl": "urn:uuid:3aa16af4-b2f6-eae4-f15f-5a243c19cf4c",
+      "fullUrl": "urn:uuid:6f33647c-f4c3-acf3-0efc-6f0140c19b76",
       "resource": {
         "resourceType": "Composition",
-        "id": "3aa16af4-b2f6-eae4-f15f-5a243c19cf4c",
+        "id": "6f33647c-f4c3-acf3-0efc-6f0140c19b76",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/ecr/StructureDefinition/eicr-composition"

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
@@ -545,7 +545,9 @@
         "name": " Sissubo School Neighbourhood Laboratory",
         "address": {
           "use": "work",
-          "line": ["4509 KAMINO OCEAN Street"],
+          "line": [
+            "4509 KAMINO OCEAN Street"
+          ],
           "city": "Galactic City",
           "state": "KZ",
           "country": "AI",
@@ -593,7 +595,9 @@
         "address": [
           {
             "use": "work",
-            "line": ["554 KAMINO OCEAN Street"],
+            "line": [
+              "554 KAMINO OCEAN Street"
+            ],
             "city": "Galactic City",
             "state": "KZ",
             "country": "AI",
@@ -635,13 +639,18 @@
         "name": [
           {
             "family": "Baba",
-            "given": ["Elzar"]
+            "given": [
+              "Elzar"
+            ]
           }
         ],
         "address": [
           {
             "use": "work",
-            "line": ["54018 KAMINO OCEAN Spire", "STE 820"],
+            "line": [
+              "54018 KAMINO OCEAN Spire",
+              "STE 820"
+            ],
             "city": "Keren",
             "state": "YA",
             "postalCode": "81303"
@@ -723,14 +732,21 @@
           {
             "use": "official",
             "family": "Powers",
-            "given": ["JohnTESTPROVIDER"],
-            "suffix": [" MD"]
+            "given": [
+              "JohnTESTPROVIDER"
+            ],
+            "suffix": [
+              " MD"
+            ]
           }
         ],
         "address": [
           {
             "use": "work",
-            "line": ["90001 TEST Avey", "STE 100"],
+            "line": [
+              "90001 TEST Avey",
+              "STE 100"
+            ],
             "city": "Washington",
             "state": "DC",
             "postalCode": "20000"
@@ -798,14 +814,21 @@
           {
             "use": "official",
             "family": "Powers",
-            "given": ["JohnTESTPROVIDER"],
-            "suffix": [" MD"]
+            "given": [
+              "JohnTESTPROVIDER"
+            ],
+            "suffix": [
+              " MD"
+            ]
           }
         ],
         "address": [
           {
             "use": "work",
-            "line": ["90001 TEST Avey", "STE 100"],
+            "line": [
+              "90001 TEST Avey",
+              "STE 100"
+            ],
             "city": "Washington",
             "state": "DC",
             "postalCode": "20000"
@@ -1045,7 +1068,9 @@
           {
             "use": "official",
             "family": "Erso",
-            "given": ["Fo"]
+            "given": [
+              "Fo"
+            ]
           }
         ],
         "birthDate": "1860-10-14",
@@ -1103,7 +1128,9 @@
         "address": [
           {
             "use": "home",
-            "line": ["9897 Kamino Ocean Street"],
+            "line": [
+              "9897 Kamino Ocean Street"
+            ],
             "city": "Galactic City",
             "state": "KZ",
             "country": "AI",
@@ -1115,7 +1142,9 @@
           },
           {
             "use": "temp",
-            "line": ["6903 KAMINO OCEAN Ave"],
+            "line": [
+              "6903 KAMINO OCEAN Ave"
+            ],
             "city": "Galactic City",
             "state": "KZ",
             "country": "AI",
@@ -1732,7 +1761,9 @@
         "resourceType": "Observation",
         "id": "53efc2c6-471a-4c02-9741-314d6f12c316",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -1781,7 +1812,9 @@
         "resourceType": "Observation",
         "id": "05c83a6a-75a4-4412-6181-611dda4ff0c7",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -1835,7 +1868,9 @@
         "resourceType": "Observation",
         "id": "0b1fe97a-5fb3-3fe2-cbf3-e4e366a6ef24",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -1889,7 +1924,9 @@
         "resourceType": "Observation",
         "id": "3c5350b1-f997-2c3d-ae94-baac33eb18ba",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -1929,7 +1966,9 @@
         "resourceType": "Observation",
         "id": "2254b170-8241-8f19-a7cf-3b16f6a5723e",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2005,7 +2044,9 @@
         "resourceType": "Observation",
         "id": "3c776a38-dd35-01d3-35c6-df144cfad680",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2050,7 +2091,9 @@
         "resourceType": "Observation",
         "id": "c22311ef-8f7d-12bb-6664-ae6e83e1e3ca",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2095,7 +2138,9 @@
         "resourceType": "Observation",
         "id": "3e3a58a4-5b5d-19e5-aa15-c5e020d1c83e",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2140,7 +2185,9 @@
         "resourceType": "Observation",
         "id": "a5cd7372-fca3-6ec0-d95f-20b522e3874b",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2185,7 +2232,9 @@
         "resourceType": "Observation",
         "id": "6f33916f-6dcc-58fd-6f7b-24a2a09f4b71",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2230,7 +2279,9 @@
         "resourceType": "Observation",
         "id": "5b600641-f4fd-6fc3-a996-72bb985a9c32",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2275,7 +2326,9 @@
         "resourceType": "Observation",
         "id": "084f8612-4884-3c4b-1094-a0b9771640ed",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2320,7 +2373,9 @@
         "resourceType": "Observation",
         "id": "650e7be6-e9bb-9bf3-5f39-92b00be2068b",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2365,7 +2420,9 @@
         "resourceType": "Observation",
         "id": "b7291830-dadf-ce28-ce26-567d9da8c72b",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2415,7 +2472,9 @@
         "resourceType": "Observation",
         "id": "ea36b896-e48f-b6de-c84d-497c5a22da93",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2460,7 +2519,9 @@
         "resourceType": "Observation",
         "id": "3c8fb0e6-7ae4-0ed3-e6b2-ecf93027294a",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2510,7 +2571,9 @@
         "resourceType": "Observation",
         "id": "45b44e0c-5eed-6f32-d1c7-5bdb56316312",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Observation"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
         },
         "identifier": [
           {
@@ -2573,14 +2636,21 @@
         "name": [
           {
             "family": "Baba",
-            "given": ["Elzar"],
-            "suffix": ["MD"]
+            "given": [
+              "Elzar"
+            ],
+            "suffix": [
+              "MD"
+            ]
           }
         ],
         "address": [
           {
             "use": "work",
-            "line": ["54018 KAMINO OCEAN Spire", "STE 820"],
+            "line": [
+              "54018 KAMINO OCEAN Spire",
+              "STE 820"
+            ],
             "city": "Keren",
             "state": "YA",
             "postalCode": "81303"
@@ -2870,7 +2940,9 @@
         "name": "University Medical Center & Pharmacy of Ando",
         "address": {
           "use": "work",
-          "line": ["554 KAMINO OCEAN Street"],
+          "line": [
+            "554 KAMINO OCEAN Street"
+          ],
           "city": "Galactic City",
           "state": "KZ",
           "country": "AI",

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
@@ -14,10 +14,10 @@
   "timestamp": "2020-05-05T11:05:15-04:00",
   "entry": [
     {
-      "fullUrl": "urn:uuid:dd97b10b-5d82-25f2-d660-84cdb50a4274",
+      "fullUrl": "urn:uuid:42645400-62ce-85d8-1177-a198fd7f29d7",
       "resource": {
         "resourceType": "Composition",
-        "id": "dd97b10b-5d82-25f2-d660-84cdb50a4274",
+        "id": "42645400-62ce-85d8-1177-a198fd7f29d7",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/ecr/StructureDefinition/eicr-composition"

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eicr04152020-expected.json
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eicr04152020-expected.json
@@ -14,10 +14,10 @@
   "timestamp": "2020-04-15T14:52:59-05:00",
   "entry": [
     {
-      "fullUrl": "urn:uuid:a30ec764-5438-2277-a369-66ad19fc04b7",
+      "fullUrl": "urn:uuid:5d842a76-6658-3084-e50d-f9fd82d7fc22",
       "resource": {
         "resourceType": "Composition",
-        "id": "a30ec764-5438-2277-a369-66ad19fc04b7",
+        "id": "5d842a76-6658-3084-e50d-f9fd82d7fc22",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/ecr/StructureDefinition/eicr-composition"

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eicr04152020-expected.json
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eicr04152020-expected.json
@@ -514,7 +514,9 @@
         "name": "Near North Health Service Corporation",
         "address": [
           {
-            "line": ["1276 N Clybourn"],
+            "line": [
+              "1276 N Clybourn"
+            ],
             "city": "Chicago",
             "state": "IL ",
             "country": "USA",
@@ -559,12 +561,17 @@
         "name": [
           {
             "family": "Nurse Desk",
-            "given": ["KH WH"]
+            "given": [
+              "KH WH"
+            ]
           }
         ],
         "address": [
           {
-            "line": ["Winfield Moody", "1276 N Clybourn"],
+            "line": [
+              "Winfield Moody",
+              "1276 N Clybourn"
+            ],
             "city": "Chicago",
             "state": "IL",
             "postalCode": "60653"
@@ -622,7 +629,9 @@
         "name": "Winfield Moody Health Center",
         "address": [
           {
-            "line": ["1276 N Clybourn"],
+            "line": [
+              "1276 N Clybourn"
+            ],
             "city": "Chicago",
             "state": "IL ",
             "postalCode": "60610     "
@@ -711,7 +720,9 @@
           {
             "use": "official",
             "family": "Test Patient",
-            "given": ["Erx"]
+            "given": [
+              "Erx"
+            ]
           }
         ],
         "birthDate": "1976-07-04",
@@ -759,7 +770,10 @@
         ],
         "address": [
           {
-            "line": ["215 W Ohio", "Apt 105"],
+            "line": [
+              "215 W Ohio",
+              "Apt 105"
+            ],
             "city": "Chicago",
             "state": "IL",
             "postalCode": "60654"
@@ -999,12 +1013,17 @@
         "name": [
           {
             "family": "Nemiary",
-            "given": ["Deina"]
+            "given": [
+              "Deina"
+            ]
           }
         ],
         "address": [
           {
-            "line": ["Winfield Moody", "1276 N. Clybourn"],
+            "line": [
+              "Winfield Moody",
+              "1276 N. Clybourn"
+            ],
             "city": "Chicago",
             "state": "IL",
             "postalCode": "60610"
@@ -1214,12 +1233,17 @@
         "name": [
           {
             "family": "Cox-Batson",
-            "given": ["Stephanie"]
+            "given": [
+              "Stephanie"
+            ]
           }
         ],
         "address": [
           {
-            "line": ["Winfield Moody", "1276 N. Clybourn"],
+            "line": [
+              "Winfield Moody",
+              "1276 N. Clybourn"
+            ],
             "city": "Chicago",
             "state": "IL",
             "postalCode": "60610"
@@ -1812,12 +1836,17 @@
         "name": [
           {
             "family": "Alliance",
-            "given": ["Admin"]
+            "given": [
+              "Admin"
+            ]
           }
         ],
         "address": [
           {
-            "line": ["215 W. Ohio Street", "4th Floor"],
+            "line": [
+              "215 W. Ohio Street",
+              "4th Floor"
+            ],
             "city": "Chicago",
             "state": "IL",
             "postalCode": "60654"
@@ -1862,7 +1891,9 @@
           ]
         },
         "address": {
-          "line": ["1276 N Clybourn"],
+          "line": [
+            "1276 N Clybourn"
+          ],
           "city": "Chicago",
           "state": "IL ",
           "country": "USA",
@@ -1977,12 +2008,17 @@
         "name": [
           {
             "family": "Reid",
-            "given": ["Fredrick"]
+            "given": [
+              "Fredrick"
+            ]
           }
         ],
         "address": [
           {
-            "line": ["Winfield Moody", "1276 N. Clybourn Ave"],
+            "line": [
+              "Winfield Moody",
+              "1276 N. Clybourn Ave"
+            ],
             "city": "Chicago",
             "state": "IL ",
             "postalCode": "60619"
@@ -2027,7 +2063,9 @@
           ]
         },
         "address": {
-          "line": ["4259 S. Berkeley"],
+          "line": [
+            "4259 S. Berkeley"
+          ],
           "city": "Chicago",
           "state": "IL",
           "country": "USA",
@@ -2142,12 +2180,17 @@
         "name": [
           {
             "family": "Herzan-Taylor",
-            "given": ["Elizabeth"]
+            "given": [
+              "Elizabeth"
+            ]
           }
         ],
         "address": [
           {
-            "line": ["Denny Community Health Center", "30 W. Chicago"],
+            "line": [
+              "Denny Community Health Center",
+              "30 W. Chicago"
+            ],
             "city": "Chicago",
             "state": "IL",
             "postalCode": "60610"
@@ -2278,7 +2321,9 @@
           ]
         },
         "address": {
-          "line": ["800 N Kedzie"],
+          "line": [
+            "800 N Kedzie"
+          ],
           "city": "Chicago",
           "state": "IL",
           "country": "USA",
@@ -2447,7 +2492,9 @@
           ]
         },
         "address": {
-          "line": ["834 E. 50th Street"],
+          "line": [
+            "834 E. 50th Street"
+          ],
           "city": "Chicago",
           "state": "IL",
           "country": "USA",
@@ -2652,12 +2699,17 @@
         "name": [
           {
             "family": "Greyer",
-            "given": ["Rhonda"]
+            "given": [
+              "Rhonda"
+            ]
           }
         ],
         "address": [
           {
-            "line": ["North Kostner Health Center", "1520 N. Kostner Ave."],
+            "line": [
+              "North Kostner Health Center",
+              "1520 N. Kostner Ave."
+            ],
             "city": "Chicago",
             "state": "IL",
             "country": "USA",
@@ -2703,7 +2755,9 @@
           ]
         },
         "address": {
-          "line": ["4501 N Sheridan Road"],
+          "line": [
+            "4501 N Sheridan Road"
+          ],
           "city": "Chicago",
           "state": "IL ",
           "postalCode": "60640"
@@ -2876,7 +2930,9 @@
           ]
         },
         "address": {
-          "line": ["1276 N. Clybourn"],
+          "line": [
+            "1276 N. Clybourn"
+          ],
           "city": "Chicago",
           "state": "IL",
           "country": "USA",
@@ -3070,7 +3126,9 @@
         "name": [
           {
             "family": "Midgett",
-            "given": ["Regina"]
+            "given": [
+              "Regina"
+            ]
           }
         ],
         "address": [
@@ -3185,12 +3243,17 @@
         "name": [
           {
             "family": "Lightbourne",
-            "given": ["Amber"]
+            "given": [
+              "Amber"
+            ]
           }
         ],
         "address": [
           {
-            "line": ["1276 N Clybourn", "WM"],
+            "line": [
+              "1276 N Clybourn",
+              "WM"
+            ],
             "city": "Chicago",
             "state": "IIl",
             "country": "USA"
@@ -3382,12 +3445,17 @@
         "name": [
           {
             "family": "Kittisopikul",
-            "given": ["Crystal"]
+            "given": [
+              "Crystal"
+            ]
           }
         ],
         "address": [
           {
-            "line": ["Winfield Moody", "1276 N. Clybourn"],
+            "line": [
+              "Winfield Moody",
+              "1276 N. Clybourn"
+            ],
             "city": "Chicago",
             "state": "IL",
             "postalCode": "60610"
@@ -3432,7 +3500,9 @@
           ]
         },
         "address": {
-          "line": ["30 West Chicago"],
+          "line": [
+            "30 West Chicago"
+          ],
           "city": "Chicago",
           "state": "IL",
           "country": "USA",
@@ -3547,7 +3617,9 @@
         "name": [
           {
             "family": "Arendt",
-            "given": ["Adam"]
+            "given": [
+              "Adam"
+            ]
           }
         ],
         "address": [
@@ -3676,12 +3748,17 @@
         "name": [
           {
             "family": "Alliance",
-            "given": ["Admin"]
+            "given": [
+              "Admin"
+            ]
           }
         ],
         "address": [
           {
-            "line": ["215 W. Ohio Street", "4th Floor"],
+            "line": [
+              "215 W. Ohio Street",
+              "4th Floor"
+            ],
             "city": "Chicago",
             "state": "IL",
             "postalCode": "60654"
@@ -3778,12 +3855,17 @@
         "name": [
           {
             "family": "Alliance",
-            "given": ["Admin"]
+            "given": [
+              "Admin"
+            ]
           }
         ],
         "address": [
           {
-            "line": ["215 W. Ohio Street", "4th Floor"],
+            "line": [
+              "215 W. Ohio Street",
+              "4th Floor"
+            ],
             "city": "Chicago",
             "state": "IL",
             "postalCode": "60654"


### PR DESCRIPTION
## Summary

Using document id will reduce the memory allocated to filter the entire document for the UUID generation. We are looking at a better long term fix for all usages of this filter but this should help short term.

## Related Issue

Fixes [#1351](https://app.zenhub.com/workspaces/customer-success-6480bf2ee530095ab41ebbe9/issues/gh/cdcgov/dibbs-ecr-viewer/1351)

## Acceptance Criteria

- [x]  FHIR conversion works as expected
- [x]  Update snapshot tests as necessary

## Additional Information

Viewer update PR: https://github.com/CDCgov/dibbs-ecr-viewer/pull/1436

## Checklist

- [ ] ⚠️ Create an associated `dibbs-ecr-viewer` PR & checked that things work on the front-end.
- [ ] If necessary, update any test fixtures/bundles to reflect FHIR conversion changes (in this repo and/or `dibbs-ecr-viewer`)
- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

⚠️ Do not merge this PR until the associated `dibbs-ecr-viewer` PR is created and validated. When both have been approved:
1. Merge the FHIR converter PR
2. Cut a new release of `dibbs-fhir-converter`
3. Update the [fhir-converter Dockerfile](https://github.com/CDCgov/dibbs-ecr-viewer/blob/main/containers/fhir-converter/Dockerfile) in `dibbs-ecr-viewer` with the updated release branch number.