### PR TITLE
fix: Escape special characters

### DIFF
--- a/data/Templates/eCR/DataType/Reason.liquid
+++ b/data/Templates/eCR/DataType/Reason.liquid
@@ -4,7 +4,7 @@
   "reason": [{
     "value": [{
       "concept": {
-        "text": "{{ reas_n.entry.observation.value.originalText._ }}",
+        "text": "{{ reas_n.entry.observation.value.originalText._ | escape_special_chars }}",
       }
     }]
   }],

--- a/data/Templates/eCR/Resource/Immunization.liquid
+++ b/data/Templates/eCR/Resource/Immunization.liquid
@@ -33,12 +33,12 @@
         {% endif -%}
 
         {% assign manufacturedProduct = immunization.consumable.manufacturedProduct %}
-        {% assign vaccineDisplay = manufacturedProduct.manufacturedMaterial.code.originalText.reference._ %}
+        {% assign vaccineDisplay = manufacturedProduct.manufacturedMaterial.code.originalText %}
 
         "vaccineCode": {
         {% include 'DataType/CodeableConcept', CodeableConcept: manufacturedProduct.manufacturedMaterial.code -%}
         {% if vaccineDisplay %}
-            "text": {{ vaccineDisplay | to_json_string }}
+            "text": "{% include 'Utils/TextHelper', text: vaccineDisplay %}",
         {% endif %}
         },
         "lotNumber":"{{ manufacturedProduct.manufacturedMaterial.lotNumberText._ }}",

--- a/data/Templates/eCR/Resource/MedicationStatement.liquid
+++ b/data/Templates/eCR/Resource/MedicationStatement.liquid
@@ -12,7 +12,7 @@
         ],
         "status":"{{ medicationStatement.statusCode.code | downcase | get_property: 'ValueSet/MedicationStatementStatus' }}",
         "note": {
-            "text": "{{ medicationStatement.text._ | default: medicationStatement.text.reference._ }}"
+            "text": "{%- include 'Utils/TextHelper', text: medicationStatement.text -%}"
         },
         {% assign medicationStatementTiming = nil %}
         {% assign medicationStatementEffectiveTimes = medicationStatement.effectiveTime | to_array %}
@@ -29,7 +29,7 @@
                 {% assign entries = medicationStatement.entryRelationship | to_array -%}
                 {% assign instruction = entries | where: 'act' | nested_where: "act.templateId.root", "2.16.840.1.113883.10.20.22.4.20" | first %}
                 {% if instruction %}
-                    "text": "{{ instruction.act.text._ | clean_string_from_tabs | default: instruction.act.text.reference._ }}",
+                    "text": "{%- include 'Utils/TextHelper', text: instruction.act.text -%}",
                 {% endif %}
                 {% if medicationStatementTiming %}
                     "timing":{ {% include 'DataType/Timing', Timing: medicationStatementTiming %} },

--- a/data/Templates/eCR/Resource/Observation.liquid
+++ b/data/Templates/eCR/Resource/Observation.liquid
@@ -71,7 +71,7 @@
                 {% elsif observationEntry.referenceRange.observationRange.value.low.translation.value %}
                     "low": {
                         "value":"{{ observationEntry.referenceRange.observationRange.value.low.translation.value }}",
-                        "unit":"{{ observationEntry.referenceRange.observationRange.value.low.translation.originalText._ }}",
+                        "unit":"{{ observationEntry.referenceRange.observationRange.value.low.translation.originalText._ | escape_special_chars }}",
                     },
                 {% endif -%}
                 {% if observationEntry.referenceRange.observationRange.value.high.value -%}
@@ -83,7 +83,7 @@
                 {% elsif observationEntry.referenceRange.observationRange.value.high.translation.value %}
                     "high": {
                         "value":"{{ observationEntry.referenceRange.observationRange.value.high.translation.value }}",
-                        "unit":"{{ observationEntry.referenceRange.observationRange.value.high.translation.originalText._ }}",
+                        "unit":"{{ observationEntry.referenceRange.observationRange.value.high.translation.originalText._ | escape_special_chars }}",
                     },
                 {% endif -%}
                 "type": { {% include 'DataType/CodeableConcept', CodeableConcept: observationEntry.referenceRange.observationRange.interpretationCode %} },
@@ -97,6 +97,7 @@
             {% assign entryRelationships = observationEntry.entryRelationship | to_array %}
             {% for entry in entryRelationships %}
                 {% if entry.act.templateId.root == "2.16.840.1.113883.10.20.22.4.64" -%}
+                    {% comment %} TODO ANGELA 2 {% endcomment %}
                     {% assign obsRefVal = entry.act.text.reference.value| replace: '#', '' -%}
                     {% assign noteString = text._innerText | find_inner_text_by_id: obsRefVal -%}
                     "note":

--- a/data/Templates/eCR/Resource/Observation.liquid
+++ b/data/Templates/eCR/Resource/Observation.liquid
@@ -97,7 +97,6 @@
             {% assign entryRelationships = observationEntry.entryRelationship | to_array %}
             {% for entry in entryRelationships %}
                 {% if entry.act.templateId.root == "2.16.840.1.113883.10.20.22.4.64" -%}
-                    {% comment %} TODO ANGELA 2 {% endcomment %}
                     {% assign obsRefVal = entry.act.text.reference.value| replace: '#', '' -%}
                     {% assign noteString = text._innerText | find_inner_text_by_id: obsRefVal -%}
                     "note":

--- a/data/Templates/eCR/Resource/Procedure.liquid
+++ b/data/Templates/eCR/Resource/Procedure.liquid
@@ -29,7 +29,7 @@
             {%- for rel in reasons -%}
                 {
                 {% include 'DataType/CodeableConcept', CodeableConcept: rel.observation.value -%}
-                "text": "{{ rel.observation.text._ }}"
+                 "text": "{%- include 'Utils/TextHelper', text: rel.observation.text -%}",
                 },
             {%- endfor -%}
             ],


### PR DESCRIPTION

# PULL REQUEST

## Summary

Philly was experiencing some ingestion errors related to special characters. Fixed here + a couple other additional spots.

## Related Issue

Fixes: https://github.com/CDCgov/dibbs-ecr-viewer/issues/1420

## Acceptance Criteria

## Additional Information

Test eCRs for Philly errors (I manually modified the original XMLs for testing)
- `eicr04152020` (for MedicationStatement)
- `eCR_RR_combined_3_1` (for Immunizations)

## Checklist

- [x] ⚠️ Create an associated `dibbs-ecr-viewer` PR & checked that things work on the front-end.
- [ ] If necessary, update any test fixtures/bundles to reflect FHIR conversion changes (in this repo and/or `dibbs-ecr-viewer`)
- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

⚠️ Do not merge this PR until the associated `dibbs-ecr-viewer` PR is created and validated. When both have been approved:
1. Merge the FHIR converter PR
2. Cut a new release of `dibbs-fhir-converter`
3. Update the [fhir-converter Dockerfile](https://github.com/CDCgov/dibbs-ecr-viewer/blob/main/containers/fhir-converter/Dockerfile) in `dibbs-ecr-viewer` with the updated release branch number.