### PR TITLE
fix: missing comma FHIR conversion failures

### DIFF
--- a/data/Templates/eCR/Utils/ValueHelper.liquid
+++ b/data/Templates/eCR/Utils/ValueHelper.liquid
@@ -3,13 +3,13 @@
         {% include 'DataType/Coding', Coding: value %} 
     },
 {% elsif value.code %}
-    "valueCodeableConcept" : {
+    "valueCodeableConcept": {
         {% include 'DataType/CodeableConcept', CodeableConcept: value -%}
     },
 {% elsif value["xsi:type"] == "BL" -%}
-    "valueBoolean" : {{ value.value }},
+    "valueBoolean": {{ value.value }},
 {% elsif value["xsi:type"] == "INT" -%}
-    "valueInteger" : {{ value.value }},
+    "valueInteger": {{ value.value }},
 {% elsif value["xsi:type"] == "TS" -%}
     "valueDateTime": "{{ value.value | format_as_date_time }}",
 {% elsif value.value -%}

--- a/data/Templates/eCR/Utils/ValueHelper.liquid
+++ b/data/Templates/eCR/Utils/ValueHelper.liquid
@@ -1,15 +1,15 @@
 {% if value.code and singleValued %}
     "valueCoding": { 
         {% include 'DataType/Coding', Coding: value %} 
-    }
+    },
 {% elsif value.code %}
     "valueCodeableConcept" : {
         {% include 'DataType/CodeableConcept', CodeableConcept: value -%}
     },
 {% elsif value["xsi:type"] == "BL" -%}
-    "valueBoolean" : {{ value.value }}
+    "valueBoolean" : {{ value.value }},
 {% elsif value["xsi:type"] == "INT" -%}
-    "valueInteger" : {{ value.value }}
+    "valueInteger" : {{ value.value }},
 {% elsif value["xsi:type"] == "TS" -%}
     "valueDateTime": "{{ value.value | format_as_date_time }}",
 {% elsif value.value -%}
@@ -18,26 +18,26 @@
             "value": {{ value.value | format_valuequantity }},
         {% endif %}
         {% if value.unit and value.unit != "null" -%}
-            "unit":"{{ value.unit | escape_special_chars }}",
+            "unit": "{{ value.unit | escape_special_chars }}",
         {% else %}
             {% assign unitFromValue = value.value | extract_unit %}
             {% if unitFromValue != nil %}
-                "unit":"{{ unitFromValue | escape_special_chars }}",
+                "unit": "{{ unitFromValue | escape_special_chars }}",
             {% endif -%}
         {% endif -%}
     },
 {% elsif value._ %}
-    "valueString":"{{ value._ | clean_string_from_tabs | escape_special_chars }}",
+    "valueString": "{{ value._ | clean_string_from_tabs | escape_special_chars }}",
 {% elsif value.originalText._ %}
-    "valueString":"{{ value.originalText._ | clean_string_from_tabs | escape_special_chars }}",
+    "valueString": "{{ value.originalText._ | clean_string_from_tabs | escape_special_chars }}",
 {% else %}
     {% assign ref = value.originalText.reference %}
     {% if value.reference %}
         {% assign ref = value.reference %}
     {% endif %}
     {% if ref._ %}
-        "valueString": "{{ ref._ | clean_string_from_tabs | escape_special_chars }}";
+        "valueString": "{{ ref._ | clean_string_from_tabs | escape_special_chars }}",
     {% else %}
-        "valueString":"{%- include 'Utils/TextRefHelper', ref: ref, origText: origText -%}",
+        "valueString": "{%- include 'Utils/TextRefHelper', ref: ref, origText: origText -%}",
     {% endif %}
 {% endif -%}

--- a/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Utils/ValueHelperTests.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Utils/ValueHelperTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using Dibbs.Fhir.Liquid.Converter.DataParsers;
 using Xunit;
 
 namespace Dibbs.Fhir.Liquid.Converter.UnitTests
@@ -71,12 +72,82 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests
         }
 
         [Fact]
+        public async System.Threading.Tasks.Task GivenUnitInValueStringProperlyReturnsWithValueUnit()
+        {
+            var attributes = new Dictionary<string, object>{
+                {"value", new { value = "5mg" }}
+            };
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": 5, \"unit\": \"mg\", },");
+        }
+
+        [Fact]
         public async System.Threading.Tasks.Task GivenRefInnerTextProperlyReturnsText()
         {
             var attributes = new Dictionary<string, object>{
                 {"value", new { originalText = new { reference = new { _ = "some value" }}}}
             };
             await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueString\": \"some value\",");
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task GivenValueInnerTextProperlyReturnsText()
+        {
+            var attributes = new Dictionary<string, object>{
+                {"value", new { _ = "some value" }}
+            };
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueString\": \"some value\",");
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task GivenOriginalTextInnerTextProperlyReturnsText()
+        {
+            var attributes = new Dictionary<string, object>{
+                {"value", new { originalText = new { _ = "some value" }}}
+            };
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueString\": \"some value\",");
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task GivenBooleanProperlyReturnsValueBoolean()
+        {
+            var xmlStr = @"<value xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:type=""BL"" value=""true"" />";
+            var attributes = new CcdaDataParser().Parse(xmlStr) as Dictionary<string, object>;
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueBoolean\": true,");
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task GivenIntegerProperlyReturnsValueInteger()
+        {
+            var xmlStr = @"<value xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:type=""INT"" value=""20"" />";
+            var attributes = new CcdaDataParser().Parse(xmlStr) as Dictionary<string, object>;
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueInteger\": 20,");
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task GivenTimestampProperlyReturnsValueDateTime()
+        {
+            var xmlStr = @"<value xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:type=""TS"" value=""20260522"" />";
+            var attributes = new CcdaDataParser().Parse(xmlStr) as Dictionary<string, object>;
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueDateTime\": \"2026-05-22\",");
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task GivenValueCodeSingleValuedProperlyReturnsWithValueCoding()
+        {
+            var attributes = new Dictionary<string, object>{
+                {"value", new { code = "1234" , displayName = "some coding", codeSystem = "a code system"}},
+                { "singleValued", true }
+            };
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueCoding\": { \"code\": \"1234\",\"system\": \"a code system\",\"display\": \"some coding\", },");
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task GivenValueCodeProperlyReturnsWithValueCodeableConcept()
+        {
+            var attributes = new Dictionary<string, object>{
+                {"value", new { code = "1234" , displayName = "some coding", codeSystem = "a code system"}}
+            };
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueCodeableConcept\": { \"coding\": [ { \"code\": \"1234\",\"system\": \"a code system\",\"display\": \"some coding\",},],},");
         }
     }
 }

--- a/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Utils/ValueHelperTests.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Utils/ValueHelperTests.cs
@@ -13,7 +13,7 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests
         [Fact]
         public async System.Threading.Tasks.Task GivenNoAttributeReturnsEmpty()
         {
-            await ConvertCheckLiquidTemplate(ECRPath, new Dictionary<string, object>(), "\"valueString\":\"\",");
+            await ConvertCheckLiquidTemplate(ECRPath, new Dictionary<string, object>(), "\"valueString\": \"\",");
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests
             var attributes = new Dictionary<string, object>{
                 {"value", new { value = ".29" , unit = "/d"}}
             };
-            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": 0.29, \"unit\":\"/d\", },");
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"value\": 0.29, \"unit\": \"/d\", },");
         }
 
         [Fact]
@@ -67,7 +67,16 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests
             var attributes = new Dictionary<string, object>{
                 {"value", new { value = "" , unit = "Immediate"}}
             };
-            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"unit\":\"Immediate\", },");
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueQuantity\": { \"unit\": \"Immediate\", },");
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task GivenRefInnerTextProperlyReturnsText()
+        {
+            var attributes = new Dictionary<string, object>{
+                {"value", new { originalText = new { reference = new { _ = "some value" }}}}
+            };
+            await ConvertCheckLiquidTemplate(ECRPath, attributes, "\"valueString\": \"some value\",");
         }
     }
 }


### PR DESCRIPTION
# PULL REQUEST

_PR title: Remember to name your PR descriptively and follow [conventional commits](https://cheatsheets.zip/conventional-commits)!_

## Summary

Fixes FHIR conversion failures caused by missing commas

## Related Issue

Fixes #1480

## Acceptance Criteria
- Cleared eCR Test Data > TN eCR > CDA_eICR2.xml can be converted without failing.


## Additional Information

Anything else the review team should know?

## Checklist

- [ ] ⚠️ Create an associated `dibbs-ecr-viewer` PR & checked that things work on the front-end.
- [ ] If necessary, update any test fixtures/bundles to reflect FHIR conversion changes (in this repo and/or `dibbs-ecr-viewer`)
- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

⚠️ Do not merge this PR until the associated `dibbs-ecr-viewer` PR is created and validated. When both have been approved:
1. Merge the FHIR converter PR
2. Cut a new release of `dibbs-fhir-converter`
3. Update the [fhir-converter Dockerfile](https://github.com/CDCgov/dibbs-ecr-viewer/blob/main/containers/fhir-converter/Dockerfile) in `dibbs-ecr-viewer` with the updated release branch number.