### PR TITLE
feat: Adding pregnancy D(Rh) type

### DIFF
--- a/data/Templates/eCR/Entry/Pregnancy/entry.liquid
+++ b/data/Templates/eCR/Entry/Pregnancy/entry.liquid
@@ -59,7 +59,7 @@
                 {% endfor %}
             {% else -%}
                 {% if tempId and tempId.root and tempId.root == '2.16.840.1.113883.10.20.22.4.300' %}
-                    {%  comment  %} [C-CDA PREG] D(Rh) Type - Lab {% endcomment %}
+                    {% comment %} [C-CDA PREG] D(Rh) Type - Lab {% endcomment %}
                     {% include 'Resource/Observation', observationCategory: 'laboratory', observationEntry: entry.observation, ID: observationId -%}
                 {% else %}
                     {% include 'Resource/Observation', observationCategory: 'exam', observationEntry: entry.observation, ID: observationId -%}

--- a/data/Templates/eCR/Entry/Pregnancy/entry.liquid
+++ b/data/Templates/eCR/Entry/Pregnancy/entry.liquid
@@ -59,12 +59,12 @@
                 {% endfor %}
             {% else -%}
                 {% if tempId and tempId.root and tempId.root == '2.16.840.1.113883.10.20.22.4.300' %}
-                    {%  comment  %} [C-CDA PREG] D(Rh) Type - Subject is not the patient (its the baby) so don't include the subject reference which is optional {% endcomment %}
+                    {%  comment  %} [C-CDA PREG] D(Rh) Type - Lab {% endcomment %}
                     {% include 'Resource/Observation', observationCategory: 'laboratory', observationEntry: entry.observation, ID: observationId -%}
                 {% else %}
                     {% include 'Resource/Observation', observationCategory: 'exam', observationEntry: entry.observation, ID: observationId -%}
-                    {% include 'Reference/Observation/Subject', ID: observationId, REF: fullPatientId -%}
                 {% endif -%}
+                {% include 'Reference/Observation/Subject', ID: observationId, REF: fullPatientId -%}
             {% endif -%}
         {% endfor -%}
     {% endif -%}

--- a/data/Templates/eCR/Entry/Pregnancy/entry.liquid
+++ b/data/Templates/eCR/Entry/Pregnancy/entry.liquid
@@ -60,10 +60,11 @@
             {% else -%}
                 {% if tempId and tempId.root and tempId.root == '2.16.840.1.113883.10.20.22.4.300' %}
                     {% comment %} [C-CDA PREG] D(Rh) Type - Lab {% endcomment %}
-                    {% include 'Resource/Observation', observationCategory: 'laboratory', observationEntry: entry.observation, ID: observationId -%}
+                    {% assign observationCategory = 'laboratory' %}
                 {% else %}
-                    {% include 'Resource/Observation', observationCategory: 'exam', observationEntry: entry.observation, ID: observationId -%}
+                    {% assign observationCategory = 'exam' %}
                 {% endif -%}
+                {% include 'Resource/Observation', observationCategory: observationCategory, observationEntry: entry.observation, ID: observationId -%}
                 {% include 'Reference/Observation/Subject', ID: observationId, REF: fullPatientId -%}
             {% endif -%}
         {% endfor -%}

--- a/data/Templates/eCR/Entry/Pregnancy/entry.liquid
+++ b/data/Templates/eCR/Entry/Pregnancy/entry.liquid
@@ -5,7 +5,7 @@
     {% else -%}
         {% assign templateIds = entry.observation.templateId | to_array -%}
         {% for tempId in templateIds -%}
-            {% if tempId and tempId.root and tempId.root == '2.16.840.1.113883.10.20.15.3.8' -%}
+            {% if tempId and tempId.root and tempId.root == '2.16.840.1.113883.10.20.15.3.8' or tempId.root == '2.16.840.1.113883.10.20.22.4.2' -%}
                 {% continue %}
             {% elsif tempId and tempId.root and tempId.root == '2.16.840.1.113883.10.20.30.3.34' -%}
                 {% include 'Resource/ObservationLastMenstrualPeriod', observationCategory: 'exam', observationEntry: entry.observation, ID: observationId -%}
@@ -20,7 +20,6 @@
                 {% comment %}  Supplemental pregnancy observation {% endcomment %}
                 {% include 'Resource/ObservationPregnancyStatus', observationCategory: 'exam', observationEntry: entry.observation, ID: observationId -%}
                 {% include 'Reference/Observation/Subject', ID: observationId, REF: fullPatientId -%}
-
                 {% comment %} Add supplemental pregnancy data {% endcomment %}
                 {% assign rels = entry.observation.entryRelationship | to_array %}
                 {% for rel in rels -%}
@@ -59,8 +58,13 @@
                     {% endif %}
                 {% endfor %}
             {% else -%}
-                {% include 'Resource/Observation', observationCategory: 'exam', observationEntry: entry.observation, ID: observationId -%}
-                {% include 'Reference/Observation/Subject', ID: observationId, REF: fullPatientId -%}
+                {% if tempId and tempId.root and tempId.root == '2.16.840.1.113883.10.20.22.4.300' %}
+                    {%  comment  %} [C-CDA PREG] D(Rh) Type - Subject is not the patient (its the baby) so don't include the subject reference which is optional {% endcomment %}
+                    {% include 'Resource/Observation', observationCategory: 'laboratory', observationEntry: entry.observation, ID: observationId -%}
+                {% else %}
+                    {% include 'Resource/Observation', observationCategory: 'exam', observationEntry: entry.observation, ID: observationId -%}
+                    {% include 'Reference/Observation/Subject', ID: observationId, REF: fullPatientId -%}
+                {% endif -%}
             {% endif -%}
         {% endfor -%}
     {% endif -%}

--- a/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Resource/ObservationTests.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Resource/ObservationTests.cs
@@ -182,6 +182,67 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests
             Assert.Equal(0, actualFhir.Extension.Count());
         }
 
+        [Fact]
+        public void ObservationPregnancyDRhType_Basic_AllFields()
+        {
+            var xmlStr = @"
+            <observation classCode=""OBS"" moodCode=""EVN"">
+                <!-- [C-CDA R3.1] Result Observation -->
+                <templateId root=""2.16.840.1.113883.10.20.22.4.2"" extension=""2015-08-01"" />
+                <!-- [C-CDA PREG] D(Rh) Type -->
+                <templateId root=""2.16.840.1.113883.10.20.22.4.300"" extension=""2018-04-01"" />
+                <id root=""1532f91f-7b5b-4479-94a5-f9fef1b28238"" />
+                <code code=""10331-7""
+                    displayName=""Rh [Type] in Blood""
+                    codeSystem=""2.16.840.1.113883.6.1""
+                    codeSystemName=""LOINC"" />
+                <statusCode code=""completed"" />
+                <effectiveTime value=""20170505"" />
+                <value xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" 
+                    xsi:type=""CD"" 
+                    code=""165747007""
+                    displayName=""RhD positive (finding)""
+                    codeSystem=""2.16.840.1.113883.6.96""
+                    codeSystemName=""SNOMED CT"" />
+            </observation>
+            ";
+            var parsed = new CcdaDataParser().Parse(xmlStr) as Dictionary<string, object>;
+
+            var attributes = new Dictionary<string, object>
+            {
+                { "ID", "1234" },
+                { "observationCategory", "laboratory" },
+                { "observationEntry", parsed["observation"]},
+            };
+
+            var actualFhir = GetFhirObjectFromTemplate<Observation>(ECRPath, attributes);
+
+            Assert.Equal(ResourceType.Observation.ToString(), actualFhir.TypeName);
+            Assert.NotNull(actualFhir.Id);
+
+            Assert.Equal(
+                "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-lab-result-observation",
+                actualFhir.Meta.Profile.First());
+            Assert.Equal(
+                "laboratory",
+                actualFhir.Category.First().Coding.First().Code);
+
+            Assert.Equal(ObservationStatus.Final, actualFhir.Status);
+
+            Assert.NotNull(actualFhir.Code);
+            Assert.Equal("10331-7", actualFhir.Code?.Coding?.First().Code);
+            Assert.Equal("Rh Nom (Bld)", actualFhir.Code?.Coding?.First().Display);
+            Assert.Equal("http://loinc.org", actualFhir.Code?.Coding?.First().System);
+
+            Assert.Equal("2017-05-05", (actualFhir.Effective as FhirDateTime)?.Value);
+
+            Assert.IsType<CodeableConcept>(actualFhir.Value);
+            var value = (CodeableConcept)actualFhir.Value;
+
+            Assert.Equal("165747007", value.Coding.First().Code);
+            Assert.Equal("http://snomed.info/sct", value.Coding.First().System);
+            Assert.Equal("RhD positive", value.Coding.First().Display);
+        }
 
         [Fact]
         public async System.Threading.Tasks.Task Obs_Status_GivenLabObsResultStatus_ReturnsStatusFromObs()


### PR DESCRIPTION
## Summary

D(Rh) Type Observation is a lab result observation as found here: https://build.fhir.org/observation-examples.html
Example: https://build.fhir.org/observation-example-rhstatus.json.html

This change adds support for it by re-using the existing Observation resource.

## Related Issue

Fixes [#1472](https://app.zenhub.com/workspaces/customer-success-6480bf2ee530095ab41ebbe9/issues/gh/cdcgov/dibbs-ecr-viewer/1472)

## Acceptance Criteria

- [x] Field should be converted to FHIR
- [x] Field should be added to the eCR Viewer (PR: https://github.com/CDCgov/dibbs-ecr-viewer/pull/1490)
- [x] Any relevant unit/snapshot tests should be added

## Additional Information

Anything else the review team should know?

## Checklist

- [x] ⚠️ Create an associated `dibbs-ecr-viewer` PR & checked that things work on the front-end.
- [x] If necessary, update any test fixtures/bundles to reflect FHIR conversion changes (in this repo and/or `dibbs-ecr-viewer`)
- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

⚠️ Do not merge this PR until the associated `dibbs-ecr-viewer` PR is created and validated. When both have been approved:
1. Merge the FHIR converter PR
2. Cut a new release of `dibbs-fhir-converter`
3. Update the [fhir-converter Dockerfile](https://github.com/CDCgov/dibbs-ecr-viewer/blob/main/containers/fhir-converter/Dockerfile) in `dibbs-ecr-viewer` with the updated release branch number.