### PR TITLE
fix: Remove procedures with nullFlavors

### DIFF
--- a/data/Templates/eCR/Entry/Result/entry.liquid
+++ b/data/Templates/eCR/Entry/Result/entry.liquid
@@ -20,11 +20,14 @@
     {% comment %} From 2.16.840.1.113883.10.20.15.2.3.35:2022-05-01 {% endcomment %}
     {% assign procComponents  = entry.organizer.component | to_array | where: "procedure"  %}
     {% for component in procComponents %}
-        {% assign specimenId = component.procedure | to_json_string | generate_uuid -%}
-        {% assign fullSpecimenId = specimenId | prepend: 'Specimen/' -%}
-        {% include 'Resource/SpecimenProcedure', ID: specimenId, specimenProc: component.procedure %}
-        {% include 'Reference/Specimen/Subject', ID: specimenId, REF: fullPatientId -%}
-        {% include 'Reference/DiagnosticReport/Specimen', ID: diagnosticID, REF: fullSpecimenId %}
+        {% if component.procedure.code.nullFlavor %}
+        {% else %}
+            {% assign specimenId = component.procedure | to_json_string | generate_uuid -%}
+            {% assign fullSpecimenId = specimenId | prepend: 'Specimen/' -%}
+            {% include 'Resource/SpecimenProcedure', ID: specimenId, specimenProc: component.procedure %}
+            {% include 'Reference/Specimen/Subject', ID: specimenId, REF: fullPatientId -%}
+            {% include 'Reference/DiagnosticReport/Specimen', ID: diagnosticID, REF: fullSpecimenId %}
+        {% endif %}
     {% endfor %}
 
     {% comment %} From 2.16.840.1.113883.10.20.22.4.1:2023-05-01 {% endcomment %}


### PR DESCRIPTION
# PULL REQUEST

## Summary

Empty specimen resources were being created from Epic-created `procedure` components. Fixes this by adding a check for any `nullFlavor`.

## Related Issue

NA. Issue found with pregnancy_3 from TN where it was creating empty Specimen resources.

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] ⚠️ Create an associated `dibbs-ecr-viewer` PR & checked that things work on the front-end.
- [ ] If necessary, update any test fixtures/bundles to reflect FHIR conversion changes (in this repo and/or `dibbs-ecr-viewer`)
- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

⚠️ Do not merge this PR until the associated `dibbs-ecr-viewer` PR is created and validated. When both have been approved:
1. Merge the FHIR converter PR
2. Cut a new release of `dibbs-fhir-converter`
3. Update the [fhir-converter Dockerfile](https://github.com/CDCgov/dibbs-ecr-viewer/blob/main/containers/fhir-converter/Dockerfile) in `dibbs-ecr-viewer` with the updated release branch number.