### PR TITLE
fix: update PractitionerRole and Practitioner sharing the same ID

### DIFF
--- a/data/Templates/eCR/Header.liquid
+++ b/data/Templates/eCR/Header.liquid
@@ -44,7 +44,10 @@
 {% if responsibleParty -%}
   {% include 'Resource/PractitionerResponsibleParty', practitioner: responsibleParty, ID: practitionerId -%}
   {% assign fullPractitionerId = practitionerId | prepend: 'Practitioner/' -%}
-  {% assign practitionerRoleId =  responsibleParty | to_json_string | generate_uuid %}
+  {% comment %} The '|PractitionerRole' discriminator keeps this hash distinct from practitionerId above, which is
+  also generated from the responsibleParty object (via Utils/GenerateId) when assignedEntity has no usable id.
+  Without it, Practitioner and PractitionerRole would get identical IDs. {% endcomment %}
+  {% assign practitionerRoleId =  responsibleParty | to_json_string | append: '|PractitionerRole' | generate_uuid %}
   {% assign fullPractitionerRoleId = practitionerRoleId | prepend: 'PractitionerRole/' %}
   {% include 'Reference/PractitionerRole/Practitioner', REF: fullPractitionerId, ID: practitionerRoleId -%}
 
@@ -53,7 +56,8 @@
     {% evaluate organizationId using 'Utils/GenerateId' obj: responsibleParty.representedOrganization -%}
     {% assign fullOrganizationId = organizationId | prepend: 'Organization/' -%}
     {% include 'Resource/Organization', organization: responsibleParty.representedOrganization, ID: organizationId -%}
-    {% assign practitionerRoleId =  responsibleParty | to_json_string | generate_uuid %}
+    {% comment %} Same '|PractitionerRole' discriminator as above, recomputed here to keep this PractitionerRole id distinct from practitionerId. {% endcomment %}
+    {% assign practitionerRoleId =  responsibleParty | to_json_string | append: '|PractitionerRole' | generate_uuid %}
     {% include 'Reference/PractitionerRole/Practitioner', REF: fullPractitionerId, ID: practitionerRoleId -%}
     {% include 'Reference/PractitionerRole/Organization', REF: fullOrganizationId, ID: practitionerRoleId -%}
   {% endif %}

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/RuleBasedTemplateDirectoryProviderTests.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/RuleBasedTemplateDirectoryProviderTests.cs
@@ -47,14 +47,12 @@ namespace Dibbs.Fhir.Liquid.Converter.FunctionalTests
             await ConvertAndValidateNonemptyResource(_ccdaTemplateProvider, templateName, samplePath, rootTemplate);
         }
 
-        // We have a previously existing bug that can cause identical Practitioner and PractitionerRole IDs.
-        // Once that is addressed we can uncomment this test.
-        // [Theory]
-        // [MemberData(nameof(GetCcdaRuleBasedTestCases))]
-        // public async Task GivenDataAndTemplateDirectoryProvider_WhenConvertDataCalled_ThenValidateNonidenticalResources(string templateName, string samplePath, string rootTemplate)
-        // {
-        //     await ConvertAndValidateNonidenticalResources(_ccdaTemplateProvider, templateName, samplePath, rootTemplate);
-        // }
+        [Theory]
+        [MemberData(nameof(GetCcdaRuleBasedTestCases))]
+        public async Task GivenDataAndTemplateDirectoryProvider_WhenConvertDataCalled_ThenValidateNonidenticalResources(string templateName, string samplePath, string rootTemplate)
+        {
+            await ConvertAndValidateNonidenticalResources(_ccdaTemplateProvider, templateName, samplePath, rootTemplate);
+        }
 
         [Fact]
         public async Task GivenDataAndTemplateDirectoryProvider_WhenConvertDataCalled_ThenValidateParserFunctionality()

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/CDAR2_IG_PHCASERPT_R2_D2_SAMPLE-expected.json
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/CDAR2_IG_PHCASERPT_R2_D2_SAMPLE-expected.json
@@ -449,7 +449,7 @@
               }
             ],
             "individual": {
-              "reference": "PractitionerRole/046a5b3b-8710-4f12-5c82-b481b9250030"
+              "reference": "PractitionerRole/c00b85e7-4d2e-2c14-b961-a2133bb2aedf"
             }
           }
         ]
@@ -603,7 +603,7 @@
     {
       "resource": {
         "resourceType": "PractitionerRole",
-        "id": "046a5b3b-8710-4f12-5c82-b481b9250030",
+        "id": "c00b85e7-4d2e-2c14-b961-a2133bb2aedf",
         "practitioner": {
           "reference": "Practitioner/b1788a7c-7165-936d-d3de-3a1713e2d54d"
         },

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_EveEverywoman-expected.json
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_EveEverywoman-expected.json
@@ -612,7 +612,7 @@
               }
             ],
             "individual": {
-              "reference": "PractitionerRole/ea367600-317d-9531-f989-894c5a2acccd"
+              "reference": "PractitionerRole/1a53f31d-a2d8-8673-a03e-38318b5d2e6a"
             }
           }
         ]
@@ -766,7 +766,7 @@
     {
       "resource": {
         "resourceType": "PractitionerRole",
-        "id": "ea367600-317d-9531-f989-894c5a2acccd",
+        "id": "1a53f31d-a2d8-8673-a03e-38318b5d2e6a",
         "practitioner": {
           "reference": "Practitioner/b1788a7c-7165-936d-d3de-3a1713e2d54d"
         },

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
@@ -462,7 +462,7 @@
               }
             ],
             "individual": {
-              "reference": "PractitionerRole/a6bc3538-1b2a-887a-aa60-0b526ac08e4a"
+              "reference": "PractitionerRole/c0a9aceb-6713-e3fc-28aa-21c8d4deffc2"
             }
           },
           {
@@ -681,7 +681,7 @@
     {
       "resource": {
         "resourceType": "PractitionerRole",
-        "id": "a6bc3538-1b2a-887a-aa60-0b526ac08e4a",
+        "id": "c0a9aceb-6713-e3fc-28aa-21c8d4deffc2",
         "practitioner": {
           "reference": "Practitioner/0336fa14-9dff-ad05-5971-64a8ac7e4827"
         },

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
@@ -337,7 +337,7 @@
               }
             ],
             "individual": {
-              "reference": "PractitionerRole/3c7071a2-a74f-2f17-aa12-7689452e4bf9"
+              "reference": "PractitionerRole/6d5565a3-8682-6d1a-0780-1a4236109073"
             }
           }
         ]
@@ -488,7 +488,7 @@
     {
       "resource": {
         "resourceType": "PractitionerRole",
-        "id": "3c7071a2-a74f-2f17-aa12-7689452e4bf9",
+        "id": "6d5565a3-8682-6d1a-0780-1a4236109073",
         "practitioner": {
           "reference": "Practitioner/4581f291-448a-04ad-0508-e348f799a4b0"
         },

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eicr04152020-expected.json
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eicr04152020-expected.json
@@ -359,7 +359,7 @@
               }
             ],
             "individual": {
-              "reference": "PractitionerRole/e8d30303-e0a1-2dbb-bddb-d208c95aad77"
+              "reference": "PractitionerRole/e9e5feef-d442-26aa-a72a-bfac75b004c1"
             }
           }
         ]
@@ -467,7 +467,7 @@
     {
       "resource": {
         "resourceType": "PractitionerRole",
-        "id": "e8d30303-e0a1-2dbb-bddb-d208c95aad77",
+        "id": "e9e5feef-d442-26aa-a72a-bfac75b004c1",
         "practitioner": {
           "reference": "Practitioner/e8d30303-e0a1-2dbb-bddb-d208c95aad77"
         },


### PR DESCRIPTION
# PULL REQUEST

## Summary

* Updated  PractionerRole UUID generation logic to have different ID
* Updated snapanshots and tests

## Related Issue

Fixes #1330

## Acceptance Criteria

- [x] Practitioner and PractitionerRole resources have unique IDs
- [x] Add any relevant tests needed and update snapshots

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] ⚠️ Create an associated `dibbs-ecr-viewer` PR & checked that things work on the front-end.
- [ ] If necessary, update any test fixtures/bundles to reflect FHIR conversion changes (in this repo and/or `dibbs-ecr-viewer`)
- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

⚠️ Do not merge this PR until the associated `dibbs-ecr-viewer` PR is created and validated. When both have been approved:
1. Merge the FHIR converter PR
2. Cut a new release of `dibbs-fhir-converter`
3. Update the [fhir-converter Dockerfile](https://github.com/CDCgov/dibbs-ecr-viewer/blob/main/containers/fhir-converter/Dockerfile) in `dibbs-ecr-viewer` with the updated release branch number.