### PR TITLE
build: Add initial workflow to generate rxnorm.csv from external source

### DIFF
--- a/.github/workflows/update-external-data.yml
+++ b/.github/workflows/update-external-data.yml
@@ -1,0 +1,60 @@
+name: Update from external data sources (Monthly)
+
+on:
+  #schedule:
+  #  - cron: "0 8 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  #pull-requests: write
+
+concurrency:
+  group: update-external-data
+  cancel-in-progress: false
+
+jobs:
+  update-rxnorm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Generate rxnorm.csv
+        run: |
+          set -euo pipefail
+
+          rxnorm_file="src/Dibbs.Fhir.Liquid.Converter/rxnorm.csv"
+
+          # Write to a temporary file first so a failed download cannot leave a
+          # partial rxnorm.csv behind.
+          tmp_file="$(mktemp)"
+          trap 'rm -f "$tmp_file"' EXIT
+
+          # RxNav returns active concepts as JSON. Convert it to the two-column
+          # CSV shape the converter loads at runtime: code,name.
+          curl --fail --show-error --silent --location \
+            "https://rxnav.nlm.nih.gov/REST/allstatus.json?status=active" \
+            | jq --raw-output '[["code", "name"]] + [.minConceptGroup.minConcept[] | [.rxcui, .name]] | .[] | @csv' \
+            > "$tmp_file"
+
+          # Guard against empty or malformed responses before replacing the
+          # checked-in CSV file.
+          test "$(wc -l < "$tmp_file")" -gt 1
+          mv "$tmp_file" "$rxnorm_file"
+
+      - name: Package RxNorm artifact
+        run: |
+          set -euo pipefail
+
+          # Keep repository-relative paths inside the archive so the final PR
+          # job can extract all generated data files onto a fresh checkout.
+          mkdir -p "${RUNNER_TEMP}/external-data-artifacts"
+          tar -cf "${RUNNER_TEMP}/external-data-artifacts/rxnorm.tar" src/Dibbs.Fhir.Liquid.Converter/rxnorm.csv
+
+      - name: Upload RxNorm artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: external-data-rxnorm
+          path: ${{ runner.temp }}/external-data-artifacts/rxnorm.tar
+          if-no-files-found: error

--- a/.github/workflows/update-terminology-data.yml
+++ b/.github/workflows/update-terminology-data.yml
@@ -1,4 +1,4 @@
-name: Update from external data sources (Monthly)
+name: Update terminology data from external sources (Monthly)
 
 on:
   #schedule:
@@ -10,7 +10,7 @@ permissions:
   #pull-requests: write
 
 concurrency:
-  group: update-external-data
+  group: update-terminology-data
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary

Breaking this task into the following steps:

1. (This PR) Add a basic workflow file (that can be manually triggered) that generates the data file and uploads it as an artifact - having this in main will allow me to test and iterate on the next step from a branch
2. (Future PR) Add step to automatically open a PR with changes from artifacts and enable monthly workflow

## Related Issue

Fixes [#1549](https://app.zenhub.com/workspaces/customer-success-6480bf2ee530095ab41ebbe9/issues/gh/cdcgov/dibbs-ecr-viewer/1549)

## Acceptance Criteria

- [x] Creates a new rxnorm.csv file in the FHIR converter (Step 1 - this PR)
- [ ] Opens a pull request to merge the updated csv file into main (Step 2 - future PR)

