### PR TITLE
fix: Fixing missing estimated date of delivery

### DIFF
--- a/data/Templates/eCR/Resource/ObservationPregnancyStatus.liquid
+++ b/data/Templates/eCR/Resource/ObservationPregnancyStatus.liquid
@@ -56,6 +56,7 @@
             {% assign obsRelationships = observationEntry.entryRelationship | to_array -%}
             {% for obsRelation in obsRelationships -%}
             {% assign templateIdString = obsRelation.observation.templateId.root -%}
+            {% comment %} Estimated Gestational Age of Pregnancy (2.16.840.1.113883.10.20.22.4.280), Estimated Date of Delivery (2.16.840.1.113883.10.20.22.4.297 or 2.16.840.1.113883.10.20.15.3.1) {% endcomment %}
             {% if templateIdString == '2.16.840.1.113883.10.20.22.4.280' or templateIdString == '2.16.840.1.113883.10.20.22.4.297' or templateIdString == '2.16.840.1.113883.10.20.15.3.1' -%}
             {
                 "extension": [

--- a/data/Templates/eCR/Resource/ObservationPregnancyStatus.liquid
+++ b/data/Templates/eCR/Resource/ObservationPregnancyStatus.liquid
@@ -56,7 +56,7 @@
             {% assign obsRelationships = observationEntry.entryRelationship | to_array -%}
             {% for obsRelation in obsRelationships -%}
             {% assign templateIdString = obsRelation.observation.templateId.root -%}
-            {% if templateIdString == '2.16.840.1.113883.10.20.22.4.280' or templateIdString == '2.16.840.1.113883.10.20.22.4.297' -%}
+            {% if templateIdString == '2.16.840.1.113883.10.20.22.4.280' or templateIdString == '2.16.840.1.113883.10.20.22.4.297' or templateIdString == '2.16.840.1.113883.10.20.15.3.1' -%}
             {
                 "extension": [
                     {% if obsRelation.observation.effectiveTime -%}

--- a/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Resource/ObservationPregnancyStatusTests.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Resource/ObservationPregnancyStatusTests.cs
@@ -22,70 +22,70 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests
         {
             var xmlString =
                 @"
-<observation
-    classCode=""OBS""
-    moodCode=""EVN""
-    xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance""
-    xsi:schemaLocation=""urn:hl7-org:v3 ../../../cda-core-2.0/schema/extensions/SDTC/infrastructure/cda/CDA_SDTC.xsd""
-    xmlns=""urn:hl7-org:v3""
-    xmlns:cda=""urn:hl7-org:v3""
-    xmlns:sdtc=""urn:hl7-org:sdtc""
-    xmlns:voc=""http://www.lantanagroup.com/voc"">
-  <templateId root=""2.16.840.1.113883.10.20.15.3.8"" />
-  <templateId root=""2.16.840.1.113883.10.20.22.4.293"" extension=""2020-04-01"" />
-  <id root=""bab77407-f76d-4a51-a2ed-980c8a59fe28"" />
-  <code code=""ASSERTION"" codeSystem=""2.16.840.1.113883.5.4"" />
-  <statusCode code=""completed"" />
-  <effectiveTime>
-    <low value=""20170826"" />
-  </effectiveTime>
-  <value xsi:type=""CD"" code=""77386006"" displayName=""Pregnant"" codeSystem=""2.16.840.1.113883.6.96""
-    codeSystemName=""SNOMED CT"" />
-  <methodCode code=""16310003"" displayName=""Diagnostic ultrasonography (procedure)""
-    codeSystem=""2.16.840.1.113883.6.96"" codeSystemName=""SNOMED CT"" />
-  <performer>
-    <time value=""20171001"" />
-    <assignedEntity>
-      <id nullFlavor=""NA"" />
-    </assignedEntity>
-  </performer>
-  <author>
-    <time value=""201710011035"" />
-    <assignedAuthor>
-      <id nullFlavor=""NA"" />
-    </assignedAuthor>
-  </author>
-  <entryRelationship typeCode=""REFR"">
-    <observation classCode=""OBS"" moodCode=""EVN"">
-      <templateId root=""2.16.840.1.113883.10.20.22.4.297"" extension=""2020-04-01"" />
-      <id root=""f3dfc576-2329-4f71-af3f-d500cab1146b"" />
-      <code code=""11780-4"" codeSystem=""2.16.840.1.113883.6.1""
-        displayName=""Delivery date estimated from ovulation date"" codeSystemName=""LOINC"" />
-      <statusCode code=""completed"" />
-      <effectiveTime value=""201710011015"" />
-      <value xsi:type=""TS"" value=""20170522"" />
-    </observation>
-  </entryRelationship>
-  <entryRelationship typeCode=""REFR"">
-    <observation classCode=""OBS"" moodCode=""EVN"">
-      <templateId root=""2.16.840.1.113883.10.20.22.4.280"" extension=""2020-04-01"" />
-      <id root=""9ae62b42-0e67-4ddc-8ef7-909d03732292"" />
-      <code code=""11887-7"" codeSystem=""2.16.840.1.113883.6.1""
-        displayName=""Gestational age Estimated from selected delivery date"" codeSystemName=""LOINC"" />
-      <statusCode code=""completed"" />
-      <effectiveTime value=""201710011015"" />
-      <value xsi:type=""PQ"" unit=""d"" value=""143"" />
-      <entryRelationship typeCode=""REFR"">
-        <act classCode=""ACT"" moodCode=""EVN"">
-          <templateId root=""2.16.840.1.113883.10.20.22.4.122"" />
-          <id root=""f3dfc576-2329-4f71-af3f-d500cab1146b"" />
-          <code nullFlavor=""NP"" />
-          <statusCode code=""completed"" />
-        </act>
-      </entryRelationship>
-    </observation>
-  </entryRelationship>
-</observation>";
+                <observation
+                    classCode=""OBS""
+                    moodCode=""EVN""
+                    xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance""
+                    xsi:schemaLocation=""urn:hl7-org:v3 ../../../cda-core-2.0/schema/extensions/SDTC/infrastructure/cda/CDA_SDTC.xsd""
+                    xmlns=""urn:hl7-org:v3""
+                    xmlns:cda=""urn:hl7-org:v3""
+                    xmlns:sdtc=""urn:hl7-org:sdtc""
+                    xmlns:voc=""http://www.lantanagroup.com/voc"">
+                  <templateId root=""2.16.840.1.113883.10.20.15.3.8"" />
+                  <templateId root=""2.16.840.1.113883.10.20.22.4.293"" extension=""2020-04-01"" />
+                  <id root=""bab77407-f76d-4a51-a2ed-980c8a59fe28"" />
+                  <code code=""ASSERTION"" codeSystem=""2.16.840.1.113883.5.4"" />
+                  <statusCode code=""completed"" />
+                  <effectiveTime>
+                    <low value=""20170826"" />
+                  </effectiveTime>
+                  <value xsi:type=""CD"" code=""77386006"" displayName=""Pregnant"" codeSystem=""2.16.840.1.113883.6.96""
+                    codeSystemName=""SNOMED CT"" />
+                  <methodCode code=""16310003"" displayName=""Diagnostic ultrasonography (procedure)""
+                    codeSystem=""2.16.840.1.113883.6.96"" codeSystemName=""SNOMED CT"" />
+                  <performer>
+                    <time value=""20171001"" />
+                    <assignedEntity>
+                      <id nullFlavor=""NA"" />
+                    </assignedEntity>
+                  </performer>
+                  <author>
+                    <time value=""201710011035"" />
+                    <assignedAuthor>
+                      <id nullFlavor=""NA"" />
+                    </assignedAuthor>
+                  </author>
+                  <entryRelationship typeCode=""REFR"">
+                    <observation classCode=""OBS"" moodCode=""EVN"">
+                      <templateId root=""2.16.840.1.113883.10.20.22.4.297"" extension=""2020-04-01"" />
+                      <id root=""f3dfc576-2329-4f71-af3f-d500cab1146b"" />
+                      <code code=""11780-4"" codeSystem=""2.16.840.1.113883.6.1""
+                        displayName=""Delivery date estimated from ovulation date"" codeSystemName=""LOINC"" />
+                      <statusCode code=""completed"" />
+                      <effectiveTime value=""201710011015"" />
+                      <value xsi:type=""TS"" value=""20170522"" />
+                    </observation>
+                  </entryRelationship>
+                  <entryRelationship typeCode=""REFR"">
+                    <observation classCode=""OBS"" moodCode=""EVN"">
+                      <templateId root=""2.16.840.1.113883.10.20.22.4.280"" extension=""2020-04-01"" />
+                      <id root=""9ae62b42-0e67-4ddc-8ef7-909d03732292"" />
+                      <code code=""11887-7"" codeSystem=""2.16.840.1.113883.6.1""
+                        displayName=""Gestational age Estimated from selected delivery date"" codeSystemName=""LOINC"" />
+                      <statusCode code=""completed"" />
+                      <effectiveTime value=""201710011015"" />
+                      <value xsi:type=""PQ"" unit=""d"" value=""143"" />
+                      <entryRelationship typeCode=""REFR"">
+                        <act classCode=""ACT"" moodCode=""EVN"">
+                          <templateId root=""2.16.840.1.113883.10.20.22.4.122"" />
+                          <id root=""f3dfc576-2329-4f71-af3f-d500cab1146b"" />
+                          <code nullFlavor=""NP"" />
+                          <statusCode code=""completed"" />
+                        </act>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                </observation>";
 
             var parser = new CcdaDataParser();
             var parsedXml = parser.Parse(xmlString) as Dictionary<string, object>;
@@ -172,6 +172,75 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests
             );
             ////// Estimated gestational age (days)
             Assert.Equal("2017-05-22", eddComponent.Value.ToString());
+        }
+
+        [Fact]
+        public void PregnancyStatus_EDDEntryRelationship() 
+        {
+          var xmlString = @"
+          <observation classCode=""OBS"" moodCode=""EVN"">
+							<templateId root=""2.16.840.1.113883.10.20.15.3.8""/>
+							<id extension=""Z4645605^67605^77386006"" root=""1.2.840.114350.1.13.478.2.7.1.1040.6""/>
+							<code code=""ASSERTION"" codeSystem=""2.16.840.1.113883.5.4""/>
+							<statusCode code=""completed""/>
+							<effectiveTime>
+								<low value=""20251124""/>
+							</effectiveTime>
+							<value xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" code=""77386006"" codeSystem=""2.16.840.1.113883.6.96"" codeSystemName=""SNOMED CT"" displayName=""Pregnancy"" xsi:type=""CD""/>
+							<entryRelationship typeCode=""REFR"">
+								<observation classCode=""OBS"" moodCode=""EVN"">
+									<templateId root=""2.16.840.1.113883.10.20.15.3.1""/>
+									<code code=""11778-8"" codeSystem=""2.16.840.1.113883.6.1"" codeSystemName=""LOINC"" displayName=""Estimated date of delivery""/>
+									<statusCode code=""completed""/>
+									<value xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" value=""20260817"" xsi:type=""TS""/>
+								</observation>
+							</entryRelationship>
+						</observation>";
+
+          var parser = new CcdaDataParser();
+          var parsedXml = parser.Parse(xmlString) as Dictionary<string, object>;
+
+          var attributes = new Dictionary<string, object>
+          {
+              { "ID", "1234" },
+              { "patientId", "urn:uuid:9876" },
+              { "observationCategory", "exam" },
+              { "observationEntry", parsedXml["observation"] },
+          };
+
+          var actualFhir = GetFhirObjectFromTemplate<Observation>(ECRPath, attributes);
+
+          Assert.Equal("Observation", actualFhir.TypeName);
+          Assert.NotNull(actualFhir.Id);
+          Assert.Equal(
+              "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-pregnancy-status-observation",
+              actualFhir.Meta.Profile.First()
+          );
+          Assert.NotEmpty(actualFhir.Identifier);
+          Assert.Equal("Final", actualFhir.Status.ToString());
+          Assert.Equal("http://loinc.org", actualFhir.Code.Coding.First().System);
+          Assert.Equal("82810-3", actualFhir.Code.Coding.First().Code);
+
+          Assert.Equal("2025-11-24", (actualFhir.Effective as Period).Start);
+
+          Assert.Equal("77386006", (actualFhir.Value as CodeableConcept).Coding.First().Code);
+          Assert.Equal(
+              "http://snomed.info/sct",
+              (actualFhir.Value as CodeableConcept).Coding.First().System
+          );
+
+          // Components
+          //// Estimated Date of Delivery (EDD)
+          var eddComponent = actualFhir.Component.Find(c =>
+              c.Value is Hl7.Fhir.Model.FhirDateTime
+          );
+          Assert.Equal("2026-08-17", eddComponent.Value.ToString());
+          Assert.Equal("11778-8", eddComponent.Code.Coding.First().Code);
+          Assert.Equal("http://loinc.org", eddComponent.Code.Coding.First().System);
+          Assert.Equal(
+              "Delivery date Estimated",
+              eddComponent.Code.Coding.First().Display
+          );
         }
     }
 }


### PR DESCRIPTION
## Summary

A template id for Estimated Date of Delivery was not being handled in the liquid template. Estimated date of delivery shows in viewer now (see bug for previous state):

<img width="1866" height="532" alt="image" src="https://github.com/user-attachments/assets/e34d9657-b538-4507-a74c-a0d56b55a64f" />

## Related Issue

Fixes #[1526](https://app.zenhub.com/workspaces/customer-success-6480bf2ee530095ab41ebbe9/issues/gh/cdcgov/dibbs-ecr-viewer/1526)

## Acceptance Criteria

- [x]  Converter should be updated to handle this entry relationship with tests
- [x]  Viewer should be updated to display the data with tests (PR: https://github.com/CDCgov/dibbs-ecr-viewer/pull/1630) - no additional changes were needed

## Additional Information

Anything else the review team should know?

## Checklist

- [x] ⚠️ Create an associated `dibbs-ecr-viewer` PR & checked that things work on the front-end.
- [ ] If necessary, update any test fixtures/bundles to reflect FHIR conversion changes (in this repo and/or `dibbs-ecr-viewer`)
- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

⚠️ Do not merge this PR until the associated `dibbs-ecr-viewer` PR is created and validated. When both have been approved:
1. Merge the FHIR converter PR
2. Cut a new release of `dibbs-fhir-converter`
3. Update the [fhir-converter Dockerfile](https://github.com/CDCgov/dibbs-ecr-viewer/blob/main/containers/fhir-converter/Dockerfile) in `dibbs-ecr-viewer` with the updated release branch number.