### PR TITLE
fix: Patient date and time of death are missing from viewer

### DIFF
--- a/data/Templates/eCR/Resource/Patient.liquid
+++ b/data/Templates/eCR/Resource/Patient.liquid
@@ -26,10 +26,11 @@
         ],
         "birthDate":"{{ patientRole.patient.birthTime.value | add_hyphens_date }}",
         {% assign deceasedDateValue = patientRole.patient['sdtc_deceasedTime'].value %}
+        {% assign deceasedIndValue = patientRole.patient['sdtc_deceasedInd'].value %}
         {% if deceasedDateValue %}
-            "deceasedDate": "{{ deceasedDateValue | add_hyphens_date }}",
-        {% else %}
-            "deceasedBoolean": false,
+            "deceasedDateTime": "{{ deceasedDateValue | add_hyphens_date }}",
+        {% elsif deceasedIndValue %}
+            "deceasedBoolean": {{ deceasedIndValue }},
         {% endif %}
         "gender":"{{ patientRole.patient.administrativeGenderCode.code | get_property: 'ValueSet/Gender' }}",
         "extension":

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
@@ -1404,10 +1404,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:eab945c7-49b7-d4d0-bdb0-6e6b82d34464",
+      "fullUrl": "urn:uuid:cbba39f7-13fd-45b7-b170-e174ed01e565",
       "resource": {
         "resourceType": "DiagnosticReport",
-        "id": "eab945c7-49b7-d4d0-bdb0-6e6b82d34464",
+        "id": "cbba39f7-13fd-45b7-b170-e174ed01e565",
         "identifier": [
           {
             "system": "urn:oid:1.2.840.114350.1.13.4304.2.7.2.798268",

--- a/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Parsers/CcdaDataParserTests.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Parsers/CcdaDataParserTests.cs
@@ -80,5 +80,44 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests.DataParsers
                 expectedInnerText,
                 (contents?["text"] as Dictionary<string, object>)?.GetValueOrDefault("_innerText"));
         }
+
+        [Fact]
+        public void GivenCcdaDocumentWithChildElementNamespace_WhenParse_CorrectResultShouldBeReturned()
+        {
+            // Document where "xmlns:sdtc" is defined on a child element, not on ClinicalDocument
+            var document = "<ClinicalDocument xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"urn:hl7-org:v3\">" +
+                           "<patientRole>" +
+                           "<patient xmlns:sdtc=\"urn:hl7-org:sdtc\">" +
+                           "<sdtc:raceCode code=\"2076-8\" displayName=\"Hawaiian or Other Pacific Islander\"/>" +
+                           "<sdtc:deceasedInd value=\"false\"/>" +
+                           "</patient>" +
+                           "</patientRole>" +
+                           "</ClinicalDocument>";
+            var data = _parser.Parse(document);
+            var contents = (data as Dictionary<string, object>)?.GetValueOrDefault("ClinicalDocument") as Dictionary<string, object>;
+            var patientRole = contents?.GetValueOrDefault("patientRole") as Dictionary<string, object>;
+            var patient = patientRole?.GetValueOrDefault("patient") as Dictionary<string, object>;
+
+            Assert.NotNull(patient?["sdtc_raceCode"]);
+            Assert.NotNull(patient?["sdtc_deceasedInd"]);
+        }
+
+        [Fact]
+        public void GivenCcdaDocumentWithNamespaceOnElementItself_WhenParse_CorrectResultShouldBeReturned()
+        {
+            var document = "<ClinicalDocument xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"urn:hl7-org:v3\">" +
+                           "<patientRole>" +
+                           "<patient>" +
+                           "<sdtc:deceasedInd xmlns:sdtc=\"urn:hl7-org:sdtc\" value=\"false\"/>" +
+                           "</patient>" +
+                           "</patientRole>" +
+                           "</ClinicalDocument>";
+            var data = _parser.Parse(document);
+            var contents = (data as Dictionary<string, object>)?.GetValueOrDefault("ClinicalDocument") as Dictionary<string, object>;
+            var patientRole = contents?.GetValueOrDefault("patientRole") as Dictionary<string, object>;
+            var patient = patientRole?.GetValueOrDefault("patient") as Dictionary<string, object>;
+
+            Assert.NotNull(patient?["sdtc_deceasedInd"]);
+        }
     }
 }

--- a/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Resource/PatientTests.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Resource/PatientTests.cs
@@ -314,7 +314,7 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests
             Assert.Equal(ResourceType.Patient.ToString(), actualFhir.TypeName);
             Assert.NotNull(actualFhir.Id);
 
-            Assert.Equal("2026-07-01", ((Date)actualFhir.Deceased).Value);
+            Assert.Equal("2026-07-01", ((FhirDateTime)actualFhir.Deceased).Value);
         }
     }
 }

--- a/src/Dibbs.Fhir.Liquid.Converter/DataParsers/CcdaDataParser.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter/DataParsers/CcdaDataParser.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -29,16 +29,17 @@ namespace Dibbs.Fhir.Liquid.Converter.DataParsers
                 // Serialize contents of `text` elements as string in `_innerText` child element
                 StringifyTextNodeContents(xDocument?.Root);
 
-                // Remove redundant namespaces to avoid appending namespace prefix before elements
+                // Remove redundant namespaces across the entire document to avoid appending namespace prefix before elements
                 var defaultNamespace = xDocument.Root?.GetDefaultNamespace().NamespaceName;
-                xDocument.Root?.Attributes()
+                xDocument.Root?.DescendantsAndSelf()
+                    .Attributes()
                     .Where(attribute => IsRedundantNamespaceAttribute(attribute, defaultNamespace))
                     .Remove();
 
                 // Normalize non-default namespace prefix in elements
                 var namespaces = xDocument.Root?.Attributes()
                     .Where(x => x.IsNamespaceDeclaration && x.Value != defaultNamespace);
-                NormalizeNamespacePrefix(xDocument?.Root, namespaces);
+                NormalizeNamespacePrefix(xDocument?.Root, namespaces, defaultNamespace);
 
                 // Change XText to XElement with name "_" to avoid serializing depth difference, e.g., given="foo" and given.#text="foo"
                 ReplaceTextWithElement(xDocument?.Root);
@@ -72,27 +73,43 @@ namespace Dibbs.Fhir.Liquid.Converter.DataParsers
         }
 
         /// <summary>
-        /// Replace "namespace:attribute" to "namespace_attribute" to be compatible with DotLiquids, e.g., from sdtc:raceCode to sdtc_raceCode
+        /// Replace "namespace:attribute" to "namespace_attribute" to be compatible with DotLiquids, e.g., from sdtc:raceCode to sdtc_raceCode.
         /// </summary>
-        private static void NormalizeNamespacePrefix(XElement element, IEnumerable<XAttribute> namespaces)
+        private static void NormalizeNamespacePrefix(XElement element, IEnumerable<XAttribute> namespaces, string defaultNamespace)
         {
-            if (element == null || namespaces == null)
+            if (element == null)
             {
                 return;
             }
 
-            foreach (var ns in namespaces)
+            // Collect non-default prefixed namespace declarations (e.g. xmlns:sdtc="...") declared on the current element.
+            // Exclude default namespace declarations (where LocalName is "xmlns") and declarations matching the root default namespace.
+            var localNamespaces = element.Attributes()
+                .Where(x => x.IsNamespaceDeclaration &&
+                            !string.Equals(x.Name.LocalName, "xmlns", StringComparison.InvariantCultureIgnoreCase) &&
+                            x.Value != defaultNamespace)
+                .ToList();
+
+            // Combine locally declared non-default namespaces with inherited parent namespaces
+            var currentNamespaces = localNamespaces.Count > 0
+                ? localNamespaces.Concat(namespaces ?? Enumerable.Empty<XAttribute>())
+                : namespaces;
+
+            if (currentNamespaces != null)
             {
-                if (string.Equals(ns.Value, element.Name.NamespaceName, StringComparison.InvariantCultureIgnoreCase))
+                foreach (var ns in currentNamespaces)
                 {
-                    element.Name = $"{ns.Name.LocalName}_{element.Name.LocalName}";
-                    break;
+                    if (string.Equals(ns.Value, element.Name.NamespaceName, StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        element.Name = $"{ns.Name.LocalName}_{element.Name.LocalName}";
+                        break;
+                    }
                 }
             }
 
             foreach (var childElement in element.Elements())
             {
-                NormalizeNamespacePrefix(childElement, namespaces);
+                NormalizeNamespacePrefix(childElement, currentNamespaces, defaultNamespace);
             }
         }
 


### PR DESCRIPTION
# PULL REQUEST

_PR title: Remember to name your PR descriptively and follow [conventional commits](https://cheatsheets.zip/conventional-commits)!_

## Summary

* Update logic for converting patient deceased time and boolean
* Non-default namespaces were not being taken into account when the namespace was declared in child elements
* Elements like `<sdtc:deceasedInd/>` were not being normalized to `sdtc_deceasedInd`
* Liquid templates can't consume elements with non-default namespaces if they're not normalized.

## Related Issue

Fixes #1338

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] ⚠️ Create an associated `dibbs-ecr-viewer` PR & checked that things work on the front-end.
- [ ] If necessary, update any test fixtures/bundles to reflect FHIR conversion changes (in this repo and/or `dibbs-ecr-viewer`)
- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

⚠️ Do not merge this PR until the associated `dibbs-ecr-viewer` PR is created and validated. When both have been approved:
1. Merge the FHIR converter PR
2. Cut a new release of `dibbs-fhir-converter`
3. Update the [fhir-converter Dockerfile](https://github.com/CDCgov/dibbs-ecr-viewer/blob/main/containers/fhir-converter/Dockerfile) in `dibbs-ecr-viewer` with the updated release branch number.