### PR TITLE
ci: Terminology update automation

### DIFF
--- a/.github/workflows/update-terminology-data.yml
+++ b/.github/workflows/update-terminology-data.yml
@@ -1,4 +1,4 @@
-name: Update terminology data from external sources (Monthly)
+name: Update terminology data (Monthly)
 
 on:
   #schedule:

--- a/.github/workflows/update-terminology-data.yml
+++ b/.github/workflows/update-terminology-data.yml
@@ -58,3 +58,69 @@ jobs:
           name: external-data-rxnorm
           path: ${{ runner.temp }}/external-data-artifacts/rxnorm.tar
           if-no-files-found: error
+
+  update-loinc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Generate Loinc.csv
+        env:
+          LOINC_AUTH: ${{ secrets.LOINC_AUTH }}
+        run: |
+          set -euo pipefail
+
+          loinc_zip="${RUNNER_TEMP}/loinc.zip"
+          loinc_extract_dir="${RUNNER_TEMP}/loinc"
+          loinc_file="src/Dibbs.Fhir.Liquid.Converter/Loinc.csv"
+
+          # The LOINC download API requires the Basic auth token stored in the
+          # repository's LOINC_AUTH secret.
+          if [ -z "${LOINC_AUTH}" ]; then
+            echo "LOINC_AUTH secret is required to download LOINC data."
+            exit 1
+          fi
+
+          # Download the LOINC database zip to runner temp storage so the
+          # workspace only contains files that should become artifacts.
+          curl --fail --show-error --silent --location --request GET \
+            --url "https://loinc.regenstrief.org/api/v1/Loinc/Download" \
+            --header "authorization: Basic ${LOINC_AUTH}" \
+            --output "$loinc_zip"
+
+          # The processing script expects the LoincTable/Loinc.csv file from
+          # inside the unzipped database package.
+          mkdir -p "$loinc_extract_dir"
+          unzip -q "$loinc_zip" -d "$loinc_extract_dir"
+          loinc_source_file="$(find "$loinc_extract_dir" -path "*/LoincTable/Loinc.csv" -print -quit)"
+
+          if [ -z "$loinc_source_file" ]; then
+            echo "Could not find LoincTable/Loinc.csv in the downloaded LOINC zip."
+            exit 1
+          fi
+
+          # Run from scripts/ because loinc_names.py writes to ../src/... .
+          (
+            cd scripts
+            python3 loinc_names.py "$loinc_source_file"
+          )
+
+          # Guard against empty or malformed output before packaging it.
+          test "$(wc -l < "$loinc_file")" -gt 1
+
+      - name: Package LOINC artifact
+        run: |
+          set -euo pipefail
+
+          # Keep repository-relative paths inside the archive so a future PR job
+          # can extract all generated data files onto a fresh checkout.
+          mkdir -p "${RUNNER_TEMP}/external-data-artifacts"
+          tar -cf "${RUNNER_TEMP}/external-data-artifacts/loinc.tar" src/Dibbs.Fhir.Liquid.Converter/Loinc.csv
+
+      - name: Upload LOINC artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: external-data-loinc
+          path: ${{ runner.temp }}/external-data-artifacts/loinc.tar
+          if-no-files-found: error

--- a/.github/workflows/update-terminology-data.yml
+++ b/.github/workflows/update-terminology-data.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  update-rxnorm:
+  download-rxnorm:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -59,7 +59,7 @@ jobs:
           path: ${{ runner.temp }}/external-data-artifacts/rxnorm.tar
           if-no-files-found: error
 
-  update-loinc:
+  download-loinc:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -123,4 +123,89 @@ jobs:
         with:
           name: external-data-loinc
           path: ${{ runner.temp }}/external-data-artifacts/loinc.tar
+          if-no-files-found: error
+
+  download-snomed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: scripts/.python-version
+          cache: pip
+
+      - name: Install SNOMED script dependencies
+        run: python -m pip install pandas
+
+      - name: Generate Snomed.csv
+        env:
+          UMLS_API_KEY: ${{ secrets.UMLS_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          snomed_release_json="${RUNNER_TEMP}/snomed-release.json"
+          snomed_zip="${RUNNER_TEMP}/snomed.zip"
+          snomed_extract_dir="${RUNNER_TEMP}/snomed"
+          snomed_file="src/Dibbs.Fhir.Liquid.Converter/Snomed.csv"
+
+          # The UTS download API requires the API key stored in the repository's
+          # UMLS_API_KEY secret.
+          if [ -z "${UMLS_API_KEY}" ]; then
+            echo "UMLS_API_KEY secret is required to download SNOMED data. See: https://documentation.uts.nlm.nih.gov/rest/authentication.html"
+            exit 1
+          fi
+
+          # Ask UTS for the current SNOMED CT US Edition release metadata.
+          curl --fail --show-error --silent --location --request GET \
+            --url "https://uts-ws.nlm.nih.gov/releases?current=true&releaseType=snomed-ct-us-edition" \
+            --output "$snomed_release_json"
+
+          # The release metadata includes the protected package download URL.
+          snomed_download_url="$(jq --raw-output '[.. | objects | (.downloadUrl? // .clientDownloadUrl? // empty)][0] // empty' "$snomed_release_json")"
+
+          if [ -z "$snomed_download_url" ] || [ "$snomed_download_url" = "null" ]; then
+            echo "Could not find a downloadUrl in the current SNOMED release metadata."
+            exit 1
+          fi
+
+          # Download the release package through the UTS download API. Use
+          # --data-urlencode so special characters in the package URL are safe.
+          curl --fail --show-error --silent --location --get \
+            --url "https://uts-ws.nlm.nih.gov/download" \
+            --data-urlencode "url=${snomed_download_url}" \
+            --data-urlencode "apiKey=${UMLS_API_KEY}" \
+            --output "$snomed_zip"
+
+          # The processing script discovers the current release Snapshot files
+          # under the unzipped package directory.
+          mkdir -p "$snomed_extract_dir"
+          unzip -q "$snomed_zip" -d "$snomed_extract_dir"
+
+          # Run from scripts/ because snomed_names.py writes to ../src/... by
+          # default.
+          (
+            cd scripts
+            python snomed_names.py "$snomed_extract_dir"
+          )
+
+          # Guard against empty or malformed output before packaging it.
+          test "$(wc -l < "$snomed_file")" -gt 1
+
+      - name: Package SNOMED artifact
+        run: |
+          set -euo pipefail
+
+          # Keep repository-relative paths inside the archive so a future PR job
+          # can extract all generated data files onto a fresh checkout.
+          mkdir -p "${RUNNER_TEMP}/external-data-artifacts"
+          tar -cf "${RUNNER_TEMP}/external-data-artifacts/snomed.tar" src/Dibbs.Fhir.Liquid.Converter/Snomed.csv
+
+      - name: Upload SNOMED artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: external-data-snomed
+          path: ${{ runner.temp }}/external-data-artifacts/snomed.tar
           if-no-files-found: error

--- a/.github/workflows/update-terminology-data.yml
+++ b/.github/workflows/update-terminology-data.yml
@@ -1,8 +1,8 @@
 name: Update terminology data (Monthly)
 
 on:
-  #schedule:
-  #  - cron: "0 8 1 * *"
+  schedule:
+    - cron: "0 8 1 * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/update-terminology-data.yml
+++ b/.github/workflows/update-terminology-data.yml
@@ -298,7 +298,6 @@ jobs:
 
           Before merging this PR:
           - Review the generated terminology CSV changes.
-          - Confirm the workflow completed successfully for all terminology sources.
 
           After this PR is approved:
           1. Merge this FHIR converter PR into `main`.
@@ -306,8 +305,8 @@ jobs:
              - Go to https://github.com/CDCgov/dibbs-FHIR-Converter/releases.
              - Draft a new release using the repository's current release naming/versioning convention.
              - Make sure the release target includes this merged terminology update.
-             - Generate or write release notes that mention the terminology data refresh.
-             - Publish the release and copy the exact release tag or branch name.
+             - Generate release notes that mention the terminology data refresh.
+             - Publish the release and copy the exact release tag.
           3. Open a PR in `CDCgov/dibbs-ecr-viewer` to update [`containers/fhir-converter/Dockerfile`](https://github.com/CDCgov/dibbs-ecr-viewer/blob/main/containers/fhir-converter/Dockerfile).
           4. In that Dockerfile, update the `git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch ...` value to the new FHIR converter release tag.
           5. Make sure all checks pass before merging the ECR Viewer PR.

--- a/.github/workflows/update-terminology-data.yml
+++ b/.github/workflows/update-terminology-data.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate rxnorm.csv
         run: |
@@ -53,7 +53,7 @@ jobs:
           tar -cf "${RUNNER_TEMP}/external-data-artifacts/rxnorm.tar" src/Dibbs.Fhir.Liquid.Converter/rxnorm.csv
 
       - name: Upload RxNorm artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: external-data-rxnorm
           path: ${{ runner.temp }}/external-data-artifacts/rxnorm.tar
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate Loinc.csv
         env:
@@ -119,7 +119,7 @@ jobs:
           tar -cf "${RUNNER_TEMP}/external-data-artifacts/loinc.tar" src/Dibbs.Fhir.Liquid.Converter/Loinc.csv
 
       - name: Upload LOINC artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: external-data-loinc
           path: ${{ runner.temp }}/external-data-artifacts/loinc.tar
@@ -129,7 +129,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -204,7 +204,7 @@ jobs:
           tar -cf "${RUNNER_TEMP}/external-data-artifacts/snomed.tar" src/Dibbs.Fhir.Liquid.Converter/Snomed.csv
 
       - name: Upload SNOMED artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: external-data-snomed
           path: ${{ runner.temp }}/external-data-artifacts/snomed.tar

--- a/.github/workflows/update-terminology-data.yml
+++ b/.github/workflows/update-terminology-data.yml
@@ -320,10 +320,10 @@ jobs:
             gh pr create \
               --base main \
               --head "$BRANCH_NAME" \
-              --title "Update external data sources" \
+              --title "chore: Update terminology data (Monthly)" \
               --body-file "$pr_body_file"
           else
             gh pr edit "$BRANCH_NAME" \
-              --title "Update external data sources" \
+              --title "chore: Update terminology data (Monthly)" \
               --body-file "$pr_body_file"
           fi

--- a/.github/workflows/update-terminology-data.yml
+++ b/.github/workflows/update-terminology-data.yml
@@ -132,7 +132,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version-file: scripts/.python-version
           cache: pip
@@ -209,3 +209,96 @@ jobs:
           name: external-data-snomed
           path: ${{ runner.temp }}/external-data-artifacts/snomed.tar
           if-no-files-found: error
+
+  create-pull-request:
+    runs-on: ubuntu-latest
+    needs:
+      - download-rxnorm
+      - download-loinc
+      - download-snomed
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Download generated data artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: external-data-*
+          path: ${{ runner.temp }}/external-data-artifacts
+          merge-multiple: true
+
+      - name: Apply generated data artifacts
+        run: |
+          set -euo pipefail
+
+          # Each data-source job uploads a tar archive containing
+          # repository-relative paths. Extract every archive before doing one
+          # aggregate diff.
+          artifact_count=0
+          while IFS= read -r -d '' artifact; do
+            artifact_count=$((artifact_count + 1))
+            tar -xf "$artifact"
+          done < <(find "${RUNNER_TEMP}/external-data-artifacts" -name "*.tar" -print0)
+
+          test "$artifact_count" -gt 0
+
+      - name: Check for external data changes
+        id: external_data_changes
+        run: |
+          set -euo pipefail
+
+          # Only create or update a PR when at least one generated data file
+          # differs from the version currently checked in on main.
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create pull request
+        if: steps.external_data_changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH_NAME: update-external-data
+        run: |
+          set -euo pipefail
+
+          # Author the commit as the user or app that triggered the workflow.
+          # The email follows GitHub's ID-based noreply format.
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+
+          # Fetch the existing update branch when it exists so force-with-lease
+          # can safely refresh an older automated PR.
+          git fetch origin "$BRANCH_NAME:refs/remotes/origin/$BRANCH_NAME" || true
+
+          # Reuse a stable branch name so monthly runs update the same PR branch
+          # instead of creating a new branch every time.
+          git checkout -B "$BRANCH_NAME"
+          git add -A
+          git commit -m "Update external data sources"
+          git push --force-with-lease origin "$BRANCH_NAME"
+
+          # Summarize the files included in this aggregate update.
+          pr_body_file="$(mktemp)"
+          {
+            echo "Updates external data source files."
+            echo
+            echo "Changed files:"
+            git show --name-only --format="" HEAD | sed '/^$/d; s/^/- /'
+          } > "$pr_body_file"
+
+          # Open a PR the first time changes are found. If a previous external
+          # data PR is still open, refresh its title and body after pushing.
+          pr_count="$(gh pr list --head "$BRANCH_NAME" --base main --state open --json number --jq length)"
+          if [ "$pr_count" -eq 0 ]; then
+            gh pr create \
+              --base main \
+              --head "$BRANCH_NAME" \
+              --title "Update external data sources" \
+              --body-file "$pr_body_file"
+          else
+            gh pr edit "$BRANCH_NAME" \
+              --title "Update external data sources" \
+              --body-file "$pr_body_file"
+          fi

--- a/.github/workflows/update-terminology-data.yml
+++ b/.github/workflows/update-terminology-data.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write
-  #pull-requests: write
+  pull-requests: write
 
 concurrency:
   group: update-terminology-data
@@ -263,14 +263,16 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Author the commit as the user or app that triggered the workflow.
-          # The email follows GitHub's ID-based noreply format.
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+          # Author the commit as the standard GitHub Actions bot so reviewers
+          # can clearly identify it as an automated terminology update.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           # Fetch the existing update branch when it exists so force-with-lease
           # can safely refresh an older automated PR.
-          git fetch origin "$BRANCH_NAME:refs/remotes/origin/$BRANCH_NAME" || true
+          if git ls-remote --exit-code --heads origin "$BRANCH_NAME" >/dev/null; then
+            git fetch origin "$BRANCH_NAME:refs/remotes/origin/$BRANCH_NAME"
+          fi
 
           # Reuse a stable branch name so monthly runs update the same PR branch
           # instead of creating a new branch every time.

--- a/.github/workflows/update-terminology-data.yml
+++ b/.github/workflows/update-terminology-data.yml
@@ -309,7 +309,8 @@ jobs:
              - Publish the release and copy the exact release tag.
           3. Open a PR in `CDCgov/dibbs-ecr-viewer` to update [`containers/fhir-converter/Dockerfile`](https://github.com/CDCgov/dibbs-ecr-viewer/blob/main/containers/fhir-converter/Dockerfile).
           4. In that Dockerfile, update the `git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch ...` value to the new FHIR converter release tag.
-          5. Make sure all checks pass before merging the ECR Viewer PR.
+          5. Make sure all checks pass before merging the eCR Viewer PR.
+          6. Once merged, create a new release of the eCR Viewer for users to receive these updates.
           PR_BODY
           } > "$pr_body_file"
 

--- a/.github/workflows/update-terminology-data.yml
+++ b/.github/workflows/update-terminology-data.yml
@@ -282,10 +282,34 @@ jobs:
           # Summarize the files included in this aggregate update.
           pr_body_file="$(mktemp)"
           {
-            echo "Updates external data source files."
-            echo
-            echo "Changed files:"
+            cat <<'PR_BODY'
+          ## Summary
+
+          Updates external terminology data files used by the FHIR converter.
+
+          ## Changed files
+          PR_BODY
             git show --name-only --format="" HEAD | sed '/^$/d; s/^/- /'
+            cat <<'PR_BODY'
+
+          ## Next steps for approvers
+
+          Before merging this PR:
+          - Review the generated terminology CSV changes.
+          - Confirm the workflow completed successfully for all terminology sources.
+
+          After this PR is approved:
+          1. Merge this FHIR converter PR into `main`.
+          2. Create a new GitHub release for `dibbs-FHIR-Converter` from the updated `main` branch:
+             - Go to https://github.com/CDCgov/dibbs-FHIR-Converter/releases.
+             - Draft a new release using the repository's current release naming/versioning convention.
+             - Make sure the release target includes this merged terminology update.
+             - Generate or write release notes that mention the terminology data refresh.
+             - Publish the release and copy the exact release tag or branch name.
+          3. Open a PR in `CDCgov/dibbs-ecr-viewer` to update [`containers/fhir-converter/Dockerfile`](https://github.com/CDCgov/dibbs-ecr-viewer/blob/main/containers/fhir-converter/Dockerfile).
+          4. In that Dockerfile, update the `git clone https://github.com/CDCgov/dibbs-FHIR-Converter.git --branch ...` value to the new FHIR converter release tag.
+          5. Make sure all checks pass before merging the ECR Viewer PR.
+          PR_BODY
           } > "$pr_body_file"
 
           # Open a PR the first time changes are found. If a previous external

--- a/.github/workflows/update-terminology-data.yml
+++ b/.github/workflows/update-terminology-data.yml
@@ -278,7 +278,7 @@ jobs:
           # instead of creating a new branch every time.
           git checkout -B "$BRANCH_NAME"
           git add -A
-          git commit -m "Update external data sources"
+          git commit -m "Update terminology data"
           git push --force-with-lease origin "$BRANCH_NAME"
 
           # Summarize the files included in this aggregate update.
@@ -287,7 +287,7 @@ jobs:
             cat <<'PR_BODY'
           ## Summary
 
-          Updates external terminology data files used by the FHIR converter.
+          Updates terminology data files used by the FHIR converter.
 
           ## Changed files
           PR_BODY

--- a/.github/workflows/update-terminology-data.yml
+++ b/.github/workflows/update-terminology-data.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 concurrency:
@@ -281,6 +282,22 @@ jobs:
           git commit -m "Update terminology data"
           git push --force-with-lease origin "$BRANCH_NAME"
 
+          # Determine which terminology files changed so the PR labels match
+          # the current aggregate update.
+          changed_files_file="$(mktemp)"
+          git show --name-only --format="" HEAD | sed '/^$/d' > "$changed_files_file"
+
+          changed_labels=()
+          if grep -Fxq "src/Dibbs.Fhir.Liquid.Converter/rxnorm.csv" "$changed_files_file"; then
+            changed_labels+=("terminology: rxnorm")
+          fi
+          if grep -Fxq "src/Dibbs.Fhir.Liquid.Converter/Loinc.csv" "$changed_files_file"; then
+            changed_labels+=("terminology: loinc")
+          fi
+          if grep -Fxq "src/Dibbs.Fhir.Liquid.Converter/Snomed.csv" "$changed_files_file"; then
+            changed_labels+=("terminology: snomed")
+          fi
+
           # Summarize the files included in this aggregate update.
           pr_body_file="$(mktemp)"
           {
@@ -291,7 +308,7 @@ jobs:
 
           ## Changed files
           PR_BODY
-            git show --name-only --format="" HEAD | sed '/^$/d; s/^/- /'
+            sed 's/^/- /' "$changed_files_file"
             cat <<'PR_BODY'
 
           ## Next steps for approvers
@@ -327,4 +344,15 @@ jobs:
             gh pr edit "$BRANCH_NAME" \
               --title "chore: Update terminology data (Monthly)" \
               --body-file "$pr_body_file"
+          fi
+
+          # Apply the pre-created labels that match the terminology files in
+          # this update. Clear old terminology labels first because this job
+          # reuses the same PR branch for each monthly run.
+          gh pr edit "$BRANCH_NAME" \
+            --remove-label "terminology: rxnorm,terminology: loinc,terminology: snomed" \
+            || true
+          if [ "${#changed_labels[@]}" -gt 0 ]; then
+            changed_labels_csv="$(IFS=,; echo "${changed_labels[*]}")"
+            gh pr edit "$BRANCH_NAME" --add-label "$changed_labels_csv"
           fi

--- a/scripts/snomed_names.py
+++ b/scripts/snomed_names.py
@@ -8,14 +8,39 @@ None: Writes `src/Dibbs.Fhir.Liquid.Converter/Snomed.csv` from the given Snomed 
 """
 
 from argparse import ArgumentParser
+from pathlib import Path
 import pandas as pd
+
+
+def find_release_file(snomed_directory, pattern):
+    matches = sorted(Path(snomed_directory).glob(pattern))
+    if len(matches) != 1:
+        raise FileNotFoundError(
+            f"Expected exactly one file matching {pattern}, found {len(matches)}"
+        )
+    return matches[0]
+
 
 parser = ArgumentParser()
 parser.add_argument("snomed_directory")
-snomed_directory = parser.parse_args().snomed_directory
+parser.add_argument(
+    "--output-path",
+    default="../src/Dibbs.Fhir.Liquid.Converter/Snomed.csv",
+)
+args = parser.parse_args()
+snomed_directory = args.snomed_directory
+
+description_file = find_release_file(
+    snomed_directory,
+    "**/Snapshot/Terminology/sct2_Description_Snapshot-en_US1000124_*.txt",
+)
+language_file = find_release_file(
+    snomed_directory,
+    "**/Snapshot/Refset/Language/der2_cRefset_LanguageSnapshot-en_US1000124_*.txt",
+)
 
 description_df = pd.read_csv(
-    snomed_directory + "/Snapshot/Terminology/sct2_Description_Snapshot-en_US1000124_20250901.txt",
+    description_file,
     delimiter="\t",
     dtype={
         "id": "string",
@@ -30,7 +55,7 @@ description_df = pd.read_csv(
     },
 )
 language_df = pd.read_csv(
-    snomed_directory + "/Snapshot/Refset/Language/der2_cRefset_LanguageSnapshot-en_US1000124_20250901.txt",
+    language_file,
     delimiter="\t",
     dtype={
         "id": "string",
@@ -52,19 +77,13 @@ merged = pd.merge(
 )
 
 filtered = merged[
-    (merged["acceptabilityId"] == "900000000000548007") # Preferred term
-    & (merged["refsetId"] == "900000000000509007")      # US English
-    & (merged["active_x"] == 1)                         # Active
+    (merged["acceptabilityId"] == "900000000000548007")  # Preferred term
+    & (merged["refsetId"] == "900000000000509007")       # US English
+    & (merged["active_x"] == 1)                          # Active
 ].sort_values(by="conceptId")
 
 deduped = filtered.loc[
     filtered.groupby("conceptId")["term"].apply(lambda x: x.str.len().idxmin())
 ]
 
-all_concept_ids = set(description_df["conceptId"])
-current_concept_ids = set(deduped["conceptId"])
-
-
-deduped[["conceptId", "term"]].to_csv(
-    "../src/Dibbs.Fhir.Liquid.Converter/Snomed.csv", index=False
-)
+deduped[["conceptId", "term"]].to_csv(args.output_path, index=False)


### PR DESCRIPTION
## Summary

Adding automation to download updated terminology for LOINC and SNOMED plus automation to open a PR for approval with instructions for next steps. 

Test workflow run: https://github.com/CDCgov/dibbs-FHIR-Converter/actions/runs/29781301787

Test PR: https://github.com/CDCgov/dibbs-FHIR-Converter/pull/151 
- I updated the title to `chore: Update terminology data (Monthly)` after I ran this test
- The actual PR will only include the CSV files, this test picked up everything since I ran it from the branch

## Related Issue

Fixes [#1551](https://app.zenhub.com/workspaces/customer-success-6480bf2ee530095ab41ebbe9/issues/gh/cdcgov/dibbs-ecr-viewer/1551) [#1550](https://app.zenhub.com/workspaces/customer-success-6480bf2ee530095ab41ebbe9/issues/gh/cdcgov/dibbs-ecr-viewer/1550)

## Acceptance Criteria

N/A

## Additional Information

Anything else the review team should know? N/A

## Checklist

- [ ] ⚠️ Create an associated `dibbs-ecr-viewer` PR & checked that things work on the front-end. (N/A)
- [ ] If necessary, update any test fixtures/bundles to reflect FHIR conversion changes (in this repo and/or `dibbs-ecr-viewer`)
- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

⚠️ Do not merge this PR until the associated `dibbs-ecr-viewer` PR is created and validated. When both have been approved:
1. Merge the FHIR converter PR
2. Cut a new release of `dibbs-fhir-converter`
3. Update the [fhir-converter Dockerfile](https://github.com/CDCgov/dibbs-ecr-viewer/blob/main/containers/fhir-converter/Dockerfile) in `dibbs-ecr-viewer` with the updated release branch number.