### PR TITLE
fix: Patient deceased dateTime formatted to include time

### DIFF
--- a/data/Templates/eCR/Resource/Patient.liquid
+++ b/data/Templates/eCR/Resource/Patient.liquid
@@ -28,7 +28,7 @@
         {% assign deceasedDateValue = patientRole.patient['sdtc_deceasedTime'].value %}
         {% assign deceasedIndValue = patientRole.patient['sdtc_deceasedInd'].value %}
         {% if deceasedDateValue %}
-            "deceasedDateTime": "{{ deceasedDateValue | add_hyphens_date }}",
+            "deceasedDateTime": "{{ deceasedDateValue | format_as_date_time }}",
         {% elsif deceasedIndValue %}
             "deceasedBoolean": {{ deceasedIndValue }},
         {% endif %}

--- a/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Resource/PatientTests.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Resource/PatientTests.cs
@@ -297,7 +297,7 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests
                 >
                     <patient>
                         <sdtc:deceasedInd value=""true"" />
-                        <sdtc:deceasedTime value=""20260701"" />
+                        <sdtc:deceasedTime value=""202607010800"" />
                     </patient>
                 </patientRole>
             ";
@@ -314,7 +314,7 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests
             Assert.Equal(ResourceType.Patient.ToString(), actualFhir.TypeName);
             Assert.NotNull(actualFhir.Id);
 
-            Assert.Equal("2026-07-01", ((FhirDateTime)actualFhir.Deceased).Value);
+            Assert.Equal("2026-07-01T08:00:00", ((FhirDateTime)actualFhir.Deceased).Value);
         }
     }
 }


### PR DESCRIPTION
# PULL REQUEST

## Summary

Fix datetime formatting for patient `deceasedDateTime`
- Previously, it used the `add_hyphens_to_date` which sets the Precision level to day.
- Now: Uses `format_as_date_time`

Also updates unit test to include deceased time

## Related Issue

Fixes https://github.com/CDCgov/dibbs-ecr-viewer/issues/1338

(FUP fix to [#1641](https://github.com/CDCgov/dibbs-ecr-viewer/pull/1641) and #149)

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] ⚠️ Create an associated `dibbs-ecr-viewer` PR & checked that things work on the front-end.
- [ ] If necessary, update any test fixtures/bundles to reflect FHIR conversion changes (in this repo and/or `dibbs-ecr-viewer`)
- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

⚠️ Do not merge this PR until the associated `dibbs-ecr-viewer` PR is created and validated. When both have been approved:
1. Merge the FHIR converter PR
2. Cut a new release of `dibbs-fhir-converter`
3. Update the [fhir-converter Dockerfile](https://github.com/CDCgov/dibbs-ecr-viewer/blob/main/containers/fhir-converter/Dockerfile) in `dibbs-ecr-viewer` with the updated release branch number.