### PR TITLE
fix: Add support for act entries and notes in social history

### DIFF
--- a/data/Templates/eCR/Entry/SocialHistory/entry.liquid
+++ b/data/Templates/eCR/Entry/SocialHistory/entry.liquid
@@ -62,5 +62,7 @@
                 {% include 'Reference/Observation/Subject', ID: relObsId, REF: fullPatientId -%}
             {% endif %}
         {% endfor %}
+    {% else %}
+        {% include 'Resource/Observation', observationCategory: 'social-history', observationEntry: entry.act, ID: observationId, text: text -%}
     {% endif %}
 {% endif -%}

--- a/data/Templates/eCR/Resource/Observation.liquid
+++ b/data/Templates/eCR/Resource/Observation.liquid
@@ -53,12 +53,11 @@
         },
         {% include 'Utils/ValueHelper', value: observationEntry.value, origText: text._innerText %}
 
-        {% if observationEntry.text.reference.value and text._innerText -%}
+        {% if observationEntry.text and text._innerText -%}
+        {% assign innerText = text._innerText %}
         "note": [
-            {% assign obsRefVal = observationEntry.text.reference.value | replace: '#', '' -%}
-            {% assign noteString = text._innerText | find_inner_text_by_id: obsRefVal -%}
             {
-                "text": "{{ noteString | strip_html | clean_string_from_tabs }}"
+                "text": "{%- include 'Utils/TextHelper', text: observationEntry.text, origText: innerText -%}" 
             }
         ],
         {% endif %}

--- a/data/Templates/eCR/Resource/Observation.liquid
+++ b/data/Templates/eCR/Resource/Observation.liquid
@@ -53,6 +53,16 @@
         },
         {% include 'Utils/ValueHelper', value: observationEntry.value, origText: text._innerText %}
 
+        {% if observationEntry.text.reference.value and text._innerText -%}
+        "note": [
+            {% assign obsRefVal = observationEntry.text.reference.value | replace: '#', '' -%}
+            {% assign noteString = text._innerText | find_inner_text_by_id: obsRefVal -%}
+            {
+                "text": "{{ noteString | strip_html | clean_string_from_tabs }}"
+            }
+        ],
+        {% endif %}
+
         {% assign range = observationEntry.referenceRange.observationRange %}
 
         {% if range and range.value %}

--- a/data/Templates/eCR/Utils/TextHelper.liquid
+++ b/data/Templates/eCR/Utils/TextHelper.liquid
@@ -1,6 +1,6 @@
 {%- assign textVal = text._ | default: text.reference._ -%}
 {%- if textVal -%}
-    {{- textVal | clean_string_from_tabs -}}
+    {{- textVal | strip_html | clean_string_from_tabs -}}
 {%- elsif text.reference -%}
     {%- include 'Utils/TextRefHelper', ref: text.reference, origText: origText -%}
 {%- endif -%}

--- a/data/Templates/eCR/Utils/TextRefHelper.liquid
+++ b/data/Templates/eCR/Utils/TextRefHelper.liquid
@@ -1,3 +1,3 @@
 {%- assign refVal = ref.value | replace: '#', '' -%}
 {%- assign valueString = origText | find_inner_text_by_id: refVal -%}
-{{- valueString | clean_string_from_tabs -}}
+{{- valueString | strip_html | clean_string_from_tabs -}}

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
@@ -1560,6 +1560,11 @@
           "value": 12,
           "unit": "g/dL"
         },
+        "note": [
+          {
+            "text": " REMOVED12REMOVED"
+          }
+        ],
         "extension": [
           {
             "url": "observation entry reference value",
@@ -1613,6 +1618,11 @@
           "value": 10000,
           "unit": "10*3/uL"
         },
+        "note": [
+          {
+            "text": " WBCREMOVEDREMOVED"
+          }
+        ],
         "referenceRange": [
           {
             "text": "REMOVED",
@@ -1683,6 +1693,11 @@
           "value": 300,
           "unit": "10*3/uL"
         },
+        "note": [
+          {
+            "text": " PLT300REMOVED"
+          }
+        ],
         "extension": [
           {
             "url": "observation entry reference value",
@@ -1736,6 +1751,11 @@
           "value": 5,
           "unit": "ng/mL"
         },
+        "note": [
+          {
+            "text": " REMOVED5REMOVED"
+          }
+        ],
         "referenceRange": [
           {
             "text": "2 ng/mL - 8 ng/mL",
@@ -1814,6 +1834,11 @@
             }
           ]
         },
+        "note": [
+          {
+            "text": "Tobacco UseTypesPacks/DayYears UsedDateSmoking Tobacco: NeverREMOVED"
+          }
+        ],
         "subject": {
           "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
         }
@@ -1870,6 +1895,11 @@
             }
           ]
         },
+        "note": [
+          {
+            "text": "REMOVED"
+          }
+        ],
         "subject": {
           "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
         }
@@ -2148,6 +2178,11 @@
           ],
           "text": "Male"
         },
+        "note": [
+          {
+            "text": "REMOVEDMaleREMOVED"
+          }
+        ],
         "subject": {
           "reference": "Patient/c4d6bcaa-3af2-aef6-17b2-abc4d53104a8"
         }

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_RR_combined_3_1-expected.json
@@ -1836,7 +1836,7 @@
         },
         "note": [
           {
-            "text": "Tobacco UseTypesPacks/DayYears UsedDateSmoking Tobacco: NeverREMOVED"
+            "text": " Tobacco Use Types Packs/Day Years Used Date Smoking Tobacco: Never REMOVED "
           }
         ],
         "subject": {
@@ -3217,7 +3217,7 @@
         "primarySource": true,
         "note": [
           {
-            "text": "<td ID=\"immunization6Name\" xmlns=\"urn:hl7-org:v3\">REMOVED</td><td xmlns=\"urn:hl7-org:v3\"> <content>REMOVED</content></td><td xmlns=\"urn:hl7-org:v3\" />"
+            "text": "REMOVED REMOVED"
           }
         ],
         "patient": {

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
@@ -885,6 +885,11 @@
             }
           ]
         },
+        "note": [
+          {
+            "text": "SARS coronavirus 2 N gene [Presence] in Unspecified specimen by Nucleic acid amplification using primer-probe set N2Detected (qualifier value)05/13/2020"
+          }
+        ],
         "extension": [
           {
             "url": "observation entry reference value",
@@ -976,6 +981,11 @@
             }
           ]
         },
+        "note": [
+          {
+            "text": "Neisseria gonorrhoeae [Presence] in Urine by NAADetected (qualifier value)05/15/2020"
+          }
+        ],
         "extension": [
           {
             "url": "observation entry reference value",
@@ -1039,6 +1049,48 @@
         },
         "subject": {
           "reference": "Patient/44e595bb-fb0b-fe20-870e-7e03122722ef"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:6c9c77ac-3bb1-00a8-5143-5b1edeb66569",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "6c9c77ac-3bb1-00a8-5143-5b1edeb66569",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:79565142-eae0-4213-a3b3-b73cdf474682"
+          }
+        ],
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "420008001",
+              "system": "http://snomed.info/sct",
+              "display": "Travel"
+            }
+          ]
+        },
+        "effectivePeriod": {
+          "start": "2020-04-22",
+          "end": "2020-05-05"
         }
       }
     },

--- a/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
+++ b/src/Dibbs.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/eCR/EICR/eCR_full-expected.json
@@ -1091,7 +1091,12 @@
         "effectivePeriod": {
           "start": "2020-04-22",
           "end": "2020-05-05"
-        }
+        },
+        "note": [
+          {
+            "text": "recent travel for vacation to Wuhan China from April 22, 2020 to May 5, 2020"
+          }
+        ]
       }
     },
     {

--- a/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Resource/ObservationTests.cs
+++ b/src/Dibbs.Fhir.Liquid.Converter.UnitTests/Templates/eCR/Resource/ObservationTests.cs
@@ -117,6 +117,47 @@ namespace Dibbs.Fhir.Liquid.Converter.UnitTests
             Assert.Equal("#ipointtohtml", refExt.Value.ToString());
         }
 
+        [Theory]
+        [InlineData(
+            "Ready to Quit: No; Counseling Given: Yes",
+            "Ready to Quit: No; Counseling Given: Yes")]
+        [InlineData(
+            "<content styleCode=\"xcellHeader\">Tobacco Cessation:</content> Ready to Quit: No; Counseling Given: Yes<br />",
+            "Tobacco Cessation: Ready to Quit: No; Counseling Given: Yes")]
+        public void ObservationTextReference_AddsPlainTextNote(string referencedText, string expectedText)
+        {
+            var xmlStr = $@"
+            <document xmlns=""urn:hl7-org:v3"">
+                <text>
+                    <paragraph ID=""observation-note"">{referencedText}</paragraph>
+                </text>
+                <observation classCode=""OBS"" moodCode=""EVN"">
+                    <id root=""bf9c0a26-4524-4395-b3ce-100450b9c9ad"" />
+                    <code code=""72166-2"" displayName=""Tobacco smoking status""
+                        codeSystem=""2.16.840.1.113883.6.1"" codeSystemName=""LOINC"" />
+                    <statusCode code=""completed"" />
+                    <text>
+                        <reference value=""#observation-note"" />
+                    </text>
+                </observation>
+            </document>";
+            var parsed = new CcdaDataParser().Parse(xmlStr) as Dictionary<string, object>;
+            var document = parsed["document"] as Dictionary<string, object>;
+
+            var attributes = new Dictionary<string, object>
+            {
+                { "ID", "1234" },
+                { "observationCategory", "social-history" },
+                { "observationEntry", document["observation"] },
+                { "text", document["text"] },
+            };
+
+            var actualFhir = GetFhirObjectFromTemplate<Observation>(ECRPath, attributes);
+
+            var note = Assert.Single(actualFhir.Note);
+            Assert.Equal(expectedText, note.Text);
+        }
+
         [Fact]
         public void ObservationVitalSign_Basic_AllFields()
         {


### PR DESCRIPTION
## Summary

Act entries in the Social History section where not being processed (only for a specific template id related to travel history). Also, text notes where not being added to the Observation resource when available. 

## Related Issue

Fixes [107](https://app.zenhub.com/workspaces/customer-success-6480bf2ee530095ab41ebbe9/issues/gh/cdcgov/dibbs-ecr-viewer/107)

## Acceptance Criteria

- [x] Tobacco use entry in Social History section includes all possible tobacco history data, including;
             Smoking Status
             Duration
             Type
             Amount
             Observation Date

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] ⚠️ Create an associated `dibbs-ecr-viewer` PR & checked that things work on the front-end.
- [ ] If necessary, update any test fixtures/bundles to reflect FHIR conversion changes (in this repo and/or `dibbs-ecr-viewer`)
- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

⚠️ Do not merge this PR until the associated `dibbs-ecr-viewer` PR is created and validated. When both have been approved:
1. Merge the FHIR converter PR
2. Cut a new release of `dibbs-fhir-converter`
3. Update the [fhir-converter Dockerfile](https://github.com/CDCgov/dibbs-ecr-viewer/blob/main/containers/fhir-converter/Dockerfile) in `dibbs-ecr-viewer` with the updated release branch number.